### PR TITLE
add support for type only when the disallow big int strings is set

### DIFF
--- a/jsonschemas/BigInts.jsonschema
+++ b/jsonschemas/BigInts.jsonschema
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "name1": {
+            "type": "integer"
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}

--- a/jsonschemas/BigIntsAllowStrings.jsonschema
+++ b/jsonschemas/BigIntsAllowStrings.jsonschema
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "name1": {
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}

--- a/main.go
+++ b/main.go
@@ -18,8 +18,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/iancoleman/strcase"
-
 	"github.com/alecthomas/jsonschema"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -38,7 +36,6 @@ const (
 
 var (
 	allowNullValues              bool = false
-	camelCase                    bool = false
 	disallowAdditionalProperties bool = false
 	disallowBigIntsAsStrings     bool = false
 	debugLogging                 bool = false
@@ -70,7 +67,6 @@ type LogLevel int
 
 func init() {
 	flag.BoolVar(&allowNullValues, "allow_null_values", false, "Allow NULL values to be validated")
-	flag.BoolVar(&camelCase, "camel_case", false, "write properties names in camel case")
 	flag.BoolVar(&disallowAdditionalProperties, "disallow_additional_properties", false, "Disallow additional properties")
 	flag.BoolVar(&disallowBigIntsAsStrings, "disallow_bigints_as_strings", false, "Disallow bigints to be strings (eg scientific notation)")
 	flag.BoolVar(&debugLogging, "debug", false, "Log debug messages")
@@ -396,12 +392,8 @@ func convertMessageType(curPkg *ProtoPackage, msg *descriptor.DescriptorProto) (
 			logWithLevel(LOG_ERROR, "Failed to convert field %s in %s: %v", fieldDesc.GetName(), msg.GetName(), err)
 			return jsonSchemaType, err
 		}
-		if camelCase {
-			fieldName := strcase.ToLowerCamel(fieldDesc.GetName())
-			jsonSchemaType.Properties[fieldName] = recursedJSONSchemaType
-		} else {
-			jsonSchemaType.Properties[fieldDesc.GetName()] = recursedJSONSchemaType
-		}
+
+		jsonSchemaType.Properties[fieldDesc.GetJsonName()] = recursedJSONSchemaType
 
 	}
 	return jsonSchemaType, nil

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/iancoleman/strcase"
+
 	"github.com/alecthomas/jsonschema"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -36,6 +38,7 @@ const (
 
 var (
 	allowNullValues              bool = false
+	camelCase                    bool = false
 	disallowAdditionalProperties bool = false
 	disallowBigIntsAsStrings     bool = false
 	debugLogging                 bool = false
@@ -392,7 +395,13 @@ func convertMessageType(curPkg *ProtoPackage, msg *descriptor.DescriptorProto) (
 			logWithLevel(LOG_ERROR, "Failed to convert field %s in %s: %v", fieldDesc.GetName(), msg.GetName(), err)
 			return jsonSchemaType, err
 		}
-		jsonSchemaType.Properties[fieldDesc.GetName()] = recursedJSONSchemaType
+		if camelCase {
+			fieldName := strcase.ToLowerCamel(fieldDesc.GetName())
+			jsonSchemaType.Properties[fieldName] = recursedJSONSchemaType
+		} else {
+			jsonSchemaType.Properties[fieldDesc.GetName()] = recursedJSONSchemaType
+		}
+
 	}
 	return jsonSchemaType, nil
 }

--- a/main.go
+++ b/main.go
@@ -215,12 +215,27 @@ func convertField(curPkg *ProtoPackage, desc *descriptor.FieldDescriptorProto, m
 		descriptor.FieldDescriptorProto_TYPE_FIXED64,
 		descriptor.FieldDescriptorProto_TYPE_SFIXED64,
 		descriptor.FieldDescriptorProto_TYPE_SINT64:
-		jsonSchemaType.OneOf = append(jsonSchemaType.OneOf, &jsonschema.Type{Type: gojsonschema.TYPE_INTEGER})
+
+		// We should keep track on whether we need a oneOf block, or whether we can get by
+		// with just type.
+		needOneOf := false
+
+		jsonSchemaType.OneOf = []*jsonschema.Type{
+			{Type: gojsonschema.TYPE_INTEGER},
+		}
 		if !disallowBigIntsAsStrings {
 			jsonSchemaType.OneOf = append(jsonSchemaType.OneOf, &jsonschema.Type{Type: gojsonschema.TYPE_STRING})
+			needOneOf = true
 		}
 		if allowNullValues {
 			jsonSchemaType.OneOf = append(jsonSchemaType.OneOf, &jsonschema.Type{Type: gojsonschema.TYPE_NULL})
+			needOneOf = true
+		}
+
+		// If we do not need the oneOf block, get rid of the original, and just use type
+		if !needOneOf {
+			jsonSchemaType.OneOf = nil
+			jsonSchemaType.Type = gojsonschema.TYPE_INTEGER
 		}
 
 	case descriptor.FieldDescriptorProto_TYPE_STRING,

--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ type LogLevel int
 
 func init() {
 	flag.BoolVar(&allowNullValues, "allow_null_values", false, "Allow NULL values to be validated")
+	flag.BoolVar(&camelCase, "camel_case", false, "write properties names in camel case")
 	flag.BoolVar(&disallowAdditionalProperties, "disallow_additional_properties", false, "Disallow additional properties")
 	flag.BoolVar(&disallowBigIntsAsStrings, "disallow_bigints_as_strings", false, "Disallow bigints to be strings (eg scientific notation)")
 	flag.BoolVar(&debugLogging, "debug", false, "Log debug messages")

--- a/main_test.go
+++ b/main_test.go
@@ -23,7 +23,6 @@ var (
 
 type SampleProto struct {
 	AllowNullValues          bool
-	CamelCase                bool
 	DisallowBigIntsAsStrings bool
 	ExpectedJsonSchema       []string
 	FilesToGenerate          []string
@@ -54,6 +53,7 @@ func TestGenerateJsonSchema(t *testing.T) {
 	testConvertSampleProtos(t, sampleProtos["ArrayOfEnums"])
 	testConvertSampleProtos(t, sampleProtos["BigInts"])
 	testConvertSampleProtos(t, sampleProtos["BigIntsAllowStrings"])
+	testConvertSampleProtos(t, sampleProtos["CamelCase"])
 }
 
 func testForProtocBinary(t *testing.T) {
@@ -70,7 +70,6 @@ func testConvertSampleProtos(t *testing.T, sampleProto SampleProto) {
 
 	// Set allowNullValues accordingly:
 	allowNullValues = sampleProto.AllowNullValues
-	camelCase = sampleProto.CamelCase
 	disallowBigIntsAsStrings = sampleProto.DisallowBigIntsAsStrings
 
 	// Open the sample proto file:
@@ -216,5 +215,14 @@ func configureSampleProtos() {
 		ExpectedJsonSchema:       []string{testdata.BigIntsAllowString},
 		FilesToGenerate:          []string{"BigIntsAllowStrings.proto"},
 		ProtoFileName:            "BigIntsAllowStrings.proto",
+	}
+
+	// BigInts, allow big ints as strings
+	sampleProtos["CamelCase"] = SampleProto{
+		AllowNullValues:          false,
+		DisallowBigIntsAsStrings: false,
+		ExpectedJsonSchema:       []string{testdata.CamelCase},
+		FilesToGenerate:          []string{"CamelCase.proto"},
+		ProtoFileName:            "CamelCase.proto",
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/chrusty/protoc-gen-jsonschema/testdata"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
+	"github.com/huttotw/protoc-gen-jsonschema/testdata"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -23,6 +23,7 @@ var (
 
 type SampleProto struct {
 	AllowNullValues          bool
+	CamelCase                bool
 	DisallowBigIntsAsStrings bool
 	ExpectedJsonSchema       []string
 	FilesToGenerate          []string
@@ -52,6 +53,8 @@ func TestGenerateJsonSchema(t *testing.T) {
 	testConvertSampleProtos(t, sampleProtos["SeveralMessages"])
 	testConvertSampleProtos(t, sampleProtos["ArrayOfEnums"])
 	testConvertSampleProtos(t, sampleProtos["BigInts"])
+	testConvertSampleProtos(t, sampleProtos["BigIntsAllowStrings"])
+	testConvertSampleProtos(t, sampleProtos["CamelCase"])
 }
 
 func testForProtocBinary(t *testing.T) {
@@ -68,6 +71,7 @@ func testConvertSampleProtos(t *testing.T, sampleProto SampleProto) {
 
 	// Set allowNullValues accordingly:
 	allowNullValues = sampleProto.AllowNullValues
+	camelCase = sampleProto.CamelCase
 	disallowBigIntsAsStrings = sampleProto.DisallowBigIntsAsStrings
 
 	// Open the sample proto file:
@@ -207,11 +211,20 @@ func configureSampleProtos() {
 	}
 
 	// BigInts, allow big ints as strings
-	sampleProtos["BigInts"] = SampleProto{
+	sampleProtos["BigIntsAllowStrings"] = SampleProto{
 		AllowNullValues:          false,
 		DisallowBigIntsAsStrings: false,
 		ExpectedJsonSchema:       []string{testdata.BigIntsAllowString},
 		FilesToGenerate:          []string{"BigIntsAllowStrings.proto"},
 		ProtoFileName:            "BigIntsAllowStrings.proto",
+	}
+
+	// CamelCase: with camelCase
+	sampleProtos["CamelCase"] = SampleProto{
+		AllowNullValues:    false,
+		CamelCase:          true,
+		ExpectedJsonSchema: []string{testdata.CamelCase},
+		FilesToGenerate:    []string{"CamelCase.proto"},
+		ProtoFileName:      "CamelCase.proto",
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -22,10 +22,11 @@ var (
 )
 
 type SampleProto struct {
-	AllowNullValues    bool
-	ExpectedJsonSchema []string
-	FilesToGenerate    []string
-	ProtoFileName      string
+	AllowNullValues          bool
+	DisallowBigIntsAsStrings bool
+	ExpectedJsonSchema       []string
+	FilesToGenerate          []string
+	ProtoFileName            string
 }
 
 func TestGenerateJsonSchema(t *testing.T) {
@@ -50,6 +51,7 @@ func TestGenerateJsonSchema(t *testing.T) {
 	testConvertSampleProtos(t, sampleProtos["SeveralEnums"])
 	testConvertSampleProtos(t, sampleProtos["SeveralMessages"])
 	testConvertSampleProtos(t, sampleProtos["ArrayOfEnums"])
+	testConvertSampleProtos(t, sampleProtos["BigInts"])
 }
 
 func testForProtocBinary(t *testing.T) {
@@ -66,6 +68,7 @@ func testConvertSampleProtos(t *testing.T, sampleProto SampleProto) {
 
 	// Set allowNullValues accordingly:
 	allowNullValues = sampleProto.AllowNullValues
+	disallowBigIntsAsStrings = sampleProto.DisallowBigIntsAsStrings
 
 	// Open the sample proto file:
 	sampleProtoFileName := fmt.Sprintf("%v/%v", sampleProtoDirectory, sampleProto.ProtoFileName)
@@ -194,4 +197,21 @@ func configureSampleProtos() {
 		ProtoFileName:      "ArrayOfEnums.proto",
 	}
 
+	// BigInts, disallow big ints as strings
+	sampleProtos["BigInts"] = SampleProto{
+		AllowNullValues:          false,
+		DisallowBigIntsAsStrings: true,
+		ExpectedJsonSchema:       []string{testdata.BigInts},
+		FilesToGenerate:          []string{"BigInts.proto"},
+		ProtoFileName:            "BigInts.proto",
+	}
+
+	// BigInts, allow big ints as strings
+	sampleProtos["BigInts"] = SampleProto{
+		AllowNullValues:          false,
+		DisallowBigIntsAsStrings: false,
+		ExpectedJsonSchema:       []string{testdata.BigIntsAllowString},
+		FilesToGenerate:          []string{"BigIntsAllowStrings.proto"},
+		ProtoFileName:            "BigIntsAllowStrings.proto",
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -54,7 +54,6 @@ func TestGenerateJsonSchema(t *testing.T) {
 	testConvertSampleProtos(t, sampleProtos["ArrayOfEnums"])
 	testConvertSampleProtos(t, sampleProtos["BigInts"])
 	testConvertSampleProtos(t, sampleProtos["BigIntsAllowStrings"])
-	testConvertSampleProtos(t, sampleProtos["CamelCase"])
 }
 
 func testForProtocBinary(t *testing.T) {
@@ -217,14 +216,5 @@ func configureSampleProtos() {
 		ExpectedJsonSchema:       []string{testdata.BigIntsAllowString},
 		FilesToGenerate:          []string{"BigIntsAllowStrings.proto"},
 		ProtoFileName:            "BigIntsAllowStrings.proto",
-	}
-
-	// CamelCase: with camelCase
-	sampleProtos["CamelCase"] = SampleProto{
-		AllowNullValues:    false,
-		CamelCase:          true,
-		ExpectedJsonSchema: []string{testdata.CamelCase},
-		FilesToGenerate:    []string{"CamelCase.proto"},
-		ProtoFileName:      "CamelCase.proto",
 	}
 }

--- a/testdata/big_ints.go
+++ b/testdata/big_ints.go
@@ -1,0 +1,12 @@
+package testdata
+
+const BigInts = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "name1": {
+            "type": "integer"
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}`

--- a/testdata/big_ints_allow_strings.go
+++ b/testdata/big_ints_allow_strings.go
@@ -1,0 +1,19 @@
+package testdata
+
+const BigIntsAllowString = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "name1": {
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}`

--- a/testdata/camel_case.go
+++ b/testdata/camel_case.go
@@ -1,0 +1,21 @@
+package testdata
+
+const CamelCase = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "firstName": {
+            "type": "string"
+        },
+        "lastName": {
+            "type": "string"
+        },
+        "rating": {
+            "type": "number"
+        },
+        "threeBigUnderscores": {
+            "type": "boolean"
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}`

--- a/testdata/proto/BigInts.proto
+++ b/testdata/proto/BigInts.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package samples;
+
+message BigInts {
+    int64 name1       = 1;
+}

--- a/testdata/proto/BigIntsAllowStrings.proto
+++ b/testdata/proto/BigIntsAllowStrings.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package samples;
+
+message BigIntsAllowStrings {
+    int64 name1       = 1;
+}

--- a/testdata/proto/CamelCase.proto
+++ b/testdata/proto/CamelCase.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+package samples;
+
+message CamelCase {
+    string first_name      = 1;
+    string last_name  = 2;
+    float rating      = 3;
+    bool three_big_underscores     = 4;
+}


### PR DESCRIPTION
This fixes #8. When you specify `disallow_big_ints_as_strings`, we will use the `type` field instead of the `oneOf` field.