### PR TITLE
support google timestamps, use date-time format in json schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ samples:
 	@PATH=.:$$PATH; protoc --jsonschema_out=disallow_bigints_as_strings:jsonschemas --proto_path=testdata/proto testdata/proto/PayloadMessage.proto 2>/dev/null || echo "No messages found (PayloadMessage.proto)"
 	@PATH=.:$$PATH; protoc --jsonschema_out=disallow_bigints_as_strings:jsonschemas --proto_path=testdata/proto testdata/proto/SeveralEnums.proto 2>/dev/null || echo "No messages found (SeveralEnums.proto)"
 	@PATH=.:$$PATH; protoc --jsonschema_out=disallow_bigints_as_strings:jsonschemas --proto_path=testdata/proto testdata/proto/SeveralMessages.proto 2>/dev/null || echo "No messages found (SeveralMessages.proto)"
-	@PATH=.:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=testdata/proto testdata/proto/ArrayOfEnums.proto 2>/dev/null || echo "No messages found (SeveralMessages.proto)"
+	@PATH=.:$$PATH; protoc --jsonschema_out=disallow_bigints_as_strings:jsonschemas --proto_path=testdata/proto testdata/proto/Timestamp.proto 2>/dev/null || echo "No messages found (Timestamp.proto)"
+	@PATH=.:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=testdata/proto testdata/proto/ArrayOfEnums.proto || echo "No messages found (SeveralMessages.proto)"
 
 test:
 	@go test

--- a/jsonschemas/Timestamp.jsonschema
+++ b/jsonschemas/Timestamp.jsonschema
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "timestamp": {
+            "type": "string",
+            "format": "date-time"
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}

--- a/main.go
+++ b/main.go
@@ -270,12 +270,18 @@ func convertField(curPkg *ProtoPackage, desc *descriptor.FieldDescriptorProto, m
 
 	case descriptor.FieldDescriptorProto_TYPE_GROUP,
 		descriptor.FieldDescriptorProto_TYPE_MESSAGE:
-		jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
-		if desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_OPTIONAL {
-			jsonSchemaType.AdditionalProperties = []byte("true")
-		}
-		if desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_REQUIRED {
-			jsonSchemaType.AdditionalProperties = []byte("false")
+		switch desc.GetTypeName() {
+		case ".google.protobuf.Timestamp":
+			jsonSchemaType.Type = gojsonschema.TYPE_STRING
+			jsonSchemaType.Format = "date-time"
+		default:
+			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
+			if desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_OPTIONAL {
+				jsonSchemaType.AdditionalProperties = []byte("true")
+			}
+			if desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_REQUIRED {
+				jsonSchemaType.AdditionalProperties = []byte("false")
+			}
 		}
 
 	default:

--- a/main_test.go
+++ b/main_test.go
@@ -50,6 +50,7 @@ func TestGenerateJsonSchema(t *testing.T) {
 	testConvertSampleProtos(t, sampleProtos["SeveralEnums"])
 	testConvertSampleProtos(t, sampleProtos["SeveralMessages"])
 	testConvertSampleProtos(t, sampleProtos["ArrayOfEnums"])
+	testConvertSampleProtos(t, sampleProtos["Timestamp"])
 }
 
 func testForProtocBinary(t *testing.T) {
@@ -192,6 +193,14 @@ func configureSampleProtos() {
 		ExpectedJsonSchema: []string{testdata.ArrayOfEnums},
 		FilesToGenerate:    []string{"ArrayOfEnums.proto"},
 		ProtoFileName:      "ArrayOfEnums.proto",
+	}
+
+	// Timestamp
+	sampleProtos["Timestamp"] = SampleProto{
+		AllowNullValues:    false,
+		ExpectedJsonSchema: []string{testdata.Timestamp},
+		FilesToGenerate:    []string{"Timestamp.proto"},
+		ProtoFileName:      "Timestamp.proto",
 	}
 
 }

--- a/testdata/proto/Timestamp.proto
+++ b/testdata/proto/Timestamp.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package samples;
+
+import "google/protobuf/timestamp.proto";
+
+message Timestamp {
+    google.protobuf.Timestamp timestamp = 1;
+}

--- a/testdata/timestamp.go
+++ b/testdata/timestamp.go
@@ -1,0 +1,13 @@
+package testdata
+
+const Timestamp = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "timestamp": {
+            "type": "string",
+            "format": "date-time"
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}`


### PR DESCRIPTION
The well known type `google/protobuf/timestamp.proto` will now be represented as:

```
{
    "$schema": "http://json-schema.org/draft-04/schema#",
    "properties": {
        "timestamp": {
            "type": "string",
            "format": "date-time"
        }
    },
    "additionalProperties": true,
    "type": "object"
}
```

