### PR TITLE
Support google timestamps, use date-time format in json schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,11 @@ samples:
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=disallow_bigints_as_strings:jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/PayloadMessage.proto || echo "No messages found (PayloadMessage.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=disallow_bigints_as_strings:jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/SeveralEnums.proto || echo "No messages found (SeveralEnums.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=disallow_bigints_as_strings:jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/SeveralMessages.proto || echo "No messages found (SeveralMessages.proto)"
+	@PATH=./bin:$$PATH; protoc --jsonschema_out=disallow_bigints_as_strings:jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/Timestamp.proto || echo "No messages found (Timestamp.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/ArrayOfEnums.proto || echo "No messages found (SeveralMessages.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/Maps.proto || echo "No messages found (Maps.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/MessageWithComments.proto || echo "No messages found (MessageWithComments.proto)"
-	@PATH=./bin:$$PATH; protoc -I /usr/include --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/WellKnown.proto
+	@PATH=./bin:$$PATH; protoc -I /usr/include --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/WellKnown.proto || echo "No messages found (WellKnown.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/NoPackage.proto
 
 test:

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -51,6 +51,7 @@ func TestGenerateJsonSchema(t *testing.T) {
 	testConvertSampleProto(t, sampleProtos["Maps"])
 	testConvertSampleProto(t, sampleProtos["SelfReference"])
 	testConvertSampleProto(t, sampleProtos["CyclicalReference"])
+	testConvertSampleProto(t, sampleProtos["Timestamp"])
 }
 
 func testConvertSampleProto(t *testing.T, sampleProto sampleProto) {
@@ -203,26 +204,33 @@ func configureSampleProtos() {
 		ProtoFileName:      "MessageWithComments.proto",
 	}
 
-	// Self referencing proto message (see https://github.com/chrusty/protoc-gen-jsonschema/issues/7)
+	// Self referencing proto message (see https://github.com/chrusty/protoc-gen-jsonschema/issues/7):
 	sampleProtos["SelfReference"] = sampleProto{
 		ExpectedJSONSchema: []string{testdata.SelfReference},
 		FilesToGenerate:    []string{"SelfReference.proto"},
 		ProtoFileName:      "SelfReference.proto",
 	}
 
-	// Messages that depend on one another so as to form a cycle (see https://github.com/chrusty/protoc-gen-jsonschema/issues/20)
+	// Messages that depend on one another so as to form a cycle (see https://github.com/chrusty/protoc-gen-jsonschema/issues/20):
 	sampleProtos["CyclicalReference"] = sampleProto{
 		ExpectedJSONSchema: []string{testdata.CyclicalReferenceMessageM, testdata.CyclicalReferenceMessageFoo, testdata.CyclicalReferenceMessageBar, testdata.CyclicalReferenceMessageBaz},
 		FilesToGenerate:    []string{"CyclicalReference.proto"},
 		ProtoFileName:      "CyclicalReference.proto",
 	}
 
+	// Google's well-known types:
 	sampleProtos["WellKnown"] = sampleProto{
 		ExpectedJSONSchema: []string{testdata.WellKnown},
 		FilesToGenerate:    []string{"WellKnown.proto"},
 		ProtoFileName:      "WellKnown.proto",
 	}
 
+	// Timestamp:
+	sampleProtos["Timestamp"] = sampleProto{
+		ExpectedJSONSchema: []string{testdata.Timestamp},
+		FilesToGenerate:    []string{"Timestamp.proto"},
+		ProtoFileName:      "Timestamp.proto",
+	}
 }
 
 // Load the specified .proto files into a FileDescriptorSet. Any errors in loading/parsing will

--- a/internal/converter/testdata/proto/Timestamp.proto
+++ b/internal/converter/testdata/proto/Timestamp.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package samples;
+
+import "google/protobuf/timestamp.proto";
+
+message Timestamp {
+    google.protobuf.Timestamp timestamp = 1;
+}

--- a/internal/converter/testdata/timestamp.go
+++ b/internal/converter/testdata/timestamp.go
@@ -1,0 +1,13 @@
+package testdata
+
+const Timestamp = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "timestamp": {
+            "type": "string",
+            "format": "date-time"
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}`

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -168,14 +168,19 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			jsonSchemaType.Type = gojsonschema.TYPE_BOOLEAN
 		}
 
-	case descriptor.FieldDescriptorProto_TYPE_GROUP,
-		descriptor.FieldDescriptorProto_TYPE_MESSAGE:
-		jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
-		if desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_OPTIONAL {
-			jsonSchemaType.AdditionalProperties = []byte("true")
-		}
-		if desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_REQUIRED {
-			jsonSchemaType.AdditionalProperties = []byte("false")
+	case descriptor.FieldDescriptorProto_TYPE_GROUP, descriptor.FieldDescriptorProto_TYPE_MESSAGE:
+		switch desc.GetTypeName() {
+		case ".google.protobuf.Timestamp":
+			jsonSchemaType.Type = gojsonschema.TYPE_STRING
+			jsonSchemaType.Format = "date-time"
+		default:
+			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
+			if desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_OPTIONAL {
+				jsonSchemaType.AdditionalProperties = []byte("true")
+			}
+			if desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_REQUIRED {
+				jsonSchemaType.AdditionalProperties = []byte("false")
+			}
 		}
 
 	default:

--- a/jsonschemas/Timestamp.jsonschema
+++ b/jsonschemas/Timestamp.jsonschema
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "timestamp": {
+            "type": "string",
+            "format": "date-time"
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}


### PR DESCRIPTION
This has been resurrected from a [closed PR](https://github.com/chrusty/protoc-gen-jsonschema/pull/12/files) raised by @huttotw.

From his original PR:

The well known type google/protobuf/timestamp.proto will now be represented as:

```json
{
    "$schema": "http://json-schema.org/draft-04/schema#",
    "properties": {
        "timestamp": {
            "type": "string",
            "format": "date-time"
        }
    },
    "additionalProperties": true,
    "type": "object"
}
```
