### PR TITLE
Fixing a stack overflow (infinite recursion) when converting google.protobuf.Value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ samples:
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/MessageWithComments.proto || echo "No messages found (MessageWithComments.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/Proto2Required.proto || echo "No messages found (Proto2Required.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/Proto2NestedMessage.proto || echo "No messages found (Proto2NestedMessage.proto)"
+	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/GoogleValue.proto || echo "No messages found (GoogleValue.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=all_fields_required:jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/Proto2NestedObject.proto || echo "No messages found (Proto2NestedObject.proto)"
 	@PATH=./bin:$$PATH; protoc -I /usr/include --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/WellKnown.proto || echo "No messages found (WellKnown.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/NoPackage.proto

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -233,6 +233,11 @@ func configureSampleProtos() map[string]sampleProto {
 			FilesToGenerate:    []string{"Proto2NestedObject.proto"},
 			ProtoFileName:      "Proto2NestedObject.proto",
 		},
+		"GoogleValue": {
+			ExpectedJSONSchema: []string{testdata.GoogleValue},
+			FilesToGenerate:    []string{"GoogleValue.proto"},
+			ProtoFileName:      "GoogleValue.proto",
+		},
 	}
 }
 

--- a/internal/converter/testdata/google_value.go
+++ b/internal/converter/testdata/google_value.go
@@ -1,0 +1,19 @@
+package testdata
+
+const GoogleValue = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "arg": {
+            "oneOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "object"
+                }
+            ]
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}`

--- a/internal/converter/testdata/proto/GoogleValue.proto
+++ b/internal/converter/testdata/proto/GoogleValue.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package samples; 
+
+import "google/protobuf/struct.proto"; 
+
+message GoogleValue {
+  google.protobuf.Value arg = 1;
+}

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -30,6 +30,7 @@ var (
 		"BoolValue":   true,
 		"StringValue": true,
 		"BytesValue":  true,
+		"Value":       true,
 	}
 )
 
@@ -420,6 +421,11 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msg *descr
 			schema.OneOf = []*jsonschema.Type{
 				{Type: gojsonschema.TYPE_NULL},
 				{Type: gojsonschema.TYPE_STRING},
+			}
+		case "Value":
+			schema.OneOf = []*jsonschema.Type{
+				{Type: gojsonschema.TYPE_NULL},
+				{Type: gojsonschema.TYPE_OBJECT},
 			}
 		}
 		return schema, nil

--- a/jsonschemas/GoogleValue.jsonschema
+++ b/jsonschemas/GoogleValue.jsonschema
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "arg": {
+            "oneOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "object"
+                }
+            ]
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}


### PR DESCRIPTION
This message type expands into a struct, which expands into a struct, which expands into a struct... results in infinite recursion. The type itself can represent anything, so in JSON / JSONschema it just becomes a generic "OBJECT" I believe.

https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/value