### PR TITLE
Option to only generate fields with their JSON names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ samples:
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=disallow_bigints_as_strings:jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/SeveralMessages.proto || echo "No messages found (SeveralMessages.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=disallow_bigints_as_strings:jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/Timestamp.proto || echo "No messages found (Timestamp.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=all_fields_required:jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/PayloadMessage2.proto || echo "No messages found (PayloadMessage2.proto)"
+	@PATH=./bin:$$PATH; protoc --jsonschema_out=json_fieldnames:jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/JSONFields.proto || echo "No messages found (JSONFields.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/ArrayOfEnums.proto || echo "No messages found (SeveralMessages.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/Maps.proto || echo "No messages found (Maps.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/MessageWithComments.proto || echo "No messages found (MessageWithComments.proto)"

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ protoc \ # The protobuf compiler
 |`debug`| Enable debug logging |
 |`disallow_additional_properties`| Disallow additional properties in schema |
 |`disallow_bigints_as_strings`| Disallow big integers as strings |
+|`json_fieldnames` | Use JSON field names only |
 |`prefix_schema_files_with_package`| Prefix the output filename with package |
-|`proto_and_json_fieldnames`| Use proto and json field names |
+|`proto_and_json_fieldnames`| Use proto and JSON field names |
 
 ## Examples
 
@@ -109,6 +110,14 @@ protoc \
 protoc \
 --jsonschema_out=messages=[MessageKind10+MessageKind11]:. \
 --proto_path=testdata/proto testdata/proto/TwelveMessages.proto
+```
+
+### Generate fields with JSON names
+
+```sh
+protoc \
+--jsonschema_out=json_fieldnames:. \
+--proto_path=testdata/proto testdata/proto/ArrayOfPrimitives.proto
 ```
 
 ## Sample protos (for testing)

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/alecthomas/jsonschema v0.0.0-20190626084004-00dfc6288dec h1:aQdFubFhjKH9sH8sbfzy2G2qIY68WEzDopaW8CjfaRU=
-github.com/alecthomas/jsonschema v0.0.0-20190626084004-00dfc6288dec/go.mod h1:Juc2PrI3wtNfUwptSvAIeNx+HrETwHQs6nf+TkOJlOA=
 github.com/alecthomas/jsonschema v0.0.0-20200217214135-7152f22193c9 h1:h+KAZEUnNceFhqyH46BgwH4lk8m6pdR/3x3h7IPn7VA=
 github.com/alecthomas/jsonschema v0.0.0-20200217214135-7152f22193c9/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -27,6 +27,7 @@ type Converter struct {
 	DisallowAdditionalProperties bool
 	DisallowBigIntsAsStrings     bool
 	PrefixSchemaFilesWithPackage bool
+	UseJSONFieldnamesOnly        bool
 	UseProtoAndJSONFieldnames    bool
 	logger                       *logrus.Logger
 	sourceInfo                   *sourceCodeInfo
@@ -73,6 +74,8 @@ func (c *Converter) parseGeneratorParameters(parameters string) {
 			c.DisallowAdditionalProperties = true
 		case "disallow_bigints_as_strings":
 			c.DisallowBigIntsAsStrings = true
+		case "json_fieldnames":
+			c.UseJSONFieldnamesOnly = true
 		case "prefix_schema_files_with_package":
 			c.PrefixSchemaFilesWithPackage = true
 		case "proto_and_json_fieldnames":

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -248,6 +248,11 @@ func configureSampleProtos() map[string]sampleProto {
 			FilesToGenerate:    []string{"TwelveMessages.proto"},
 			ProtoFileName:      "TwelveMessages.proto",
 		},
+		"GoogleValue": {
+			ExpectedJSONSchema: []string{testdata.GoogleValue},
+			FilesToGenerate:    []string{"GoogleValue.proto"},
+			ProtoFileName:      "GoogleValue.proto",
+		},
 		"JSONFields": {
 			ExpectedJSONSchema:    []string{testdata.JSONFields},
 			FilesToGenerate:       []string{"JSONFields.proto"},

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -28,6 +28,7 @@ type sampleProto struct {
 	FilesToGenerate              []string
 	PrefixSchemaFilesWithPackage bool
 	ProtoFileName                string
+	UseJSONFieldnamesOnly        bool
 	UseProtoAndJSONFieldNames    bool
 	TargetedMessages             []string
 }
@@ -54,6 +55,7 @@ func testConvertSampleProto(t *testing.T, sampleProto sampleProto) {
 	protoConverter := New(logger)
 	protoConverter.AllFieldsRequired = sampleProto.AllFieldsRequired
 	protoConverter.AllowNullValues = sampleProto.AllowNullValues
+	protoConverter.UseJSONFieldnamesOnly = sampleProto.UseJSONFieldnamesOnly
 	protoConverter.UseProtoAndJSONFieldnames = sampleProto.UseProtoAndJSONFieldNames
 	protoConverter.PrefixSchemaFilesWithPackage = sampleProto.PrefixSchemaFilesWithPackage
 
@@ -246,10 +248,11 @@ func configureSampleProtos() map[string]sampleProto {
 			FilesToGenerate:    []string{"TwelveMessages.proto"},
 			ProtoFileName:      "TwelveMessages.proto",
 		},
-		"GoogleValue": {
-			ExpectedJSONSchema: []string{testdata.GoogleValue},
-			FilesToGenerate:    []string{"GoogleValue.proto"},
-			ProtoFileName:      "GoogleValue.proto",
+		"JSONFields": {
+			ExpectedJSONSchema:    []string{testdata.JSONFields},
+			FilesToGenerate:       []string{"JSONFields.proto"},
+			ProtoFileName:         "JSONFields.proto",
+			UseJSONFieldnamesOnly: true,
 		},
 	}
 }

--- a/internal/converter/testdata/json_fields.go
+++ b/internal/converter/testdata/json_fields.go
@@ -17,6 +17,16 @@ const JSONFields = `{
         },
         "complete": {
             "type": "boolean"
+        },
+        "snakeNumb": {
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "string"
+                }
+            ]
         }
     },
     "additionalProperties": true,

--- a/internal/converter/testdata/json_fields.go
+++ b/internal/converter/testdata/json_fields.go
@@ -1,4 +1,6 @@
-{
+package testdata
+
+const JSONFields = `{
     "$schema": "http://json-schema.org/draft-04/schema#",
     "properties": {
         "name": {
@@ -20,3 +22,4 @@
     "additionalProperties": true,
     "type": "object"
 }
+`

--- a/internal/converter/testdata/json_fields.go
+++ b/internal/converter/testdata/json_fields.go
@@ -6,13 +6,13 @@ const JSONFields = `{
         "name": {
             "type": "string"
         },
-        "time_stamp": {
+        "timestamp": {
             "type": "string"
         },
         "identifier": {
             "type": "integer"
         },
-        "rating": {
+        "someThing": {
             "type": "number"
         },
         "complete": {

--- a/internal/converter/testdata/proto/JSONFields.proto
+++ b/internal/converter/testdata/proto/JSONFields.proto
@@ -7,4 +7,5 @@ message JSONFields {
     int32 id         = 3 [json_name="identifier"];
     float some_thing = 4 [json_name="someThing"];
     bool complete    = 5;
+    int64 snake_numb = 6;
 }

--- a/internal/converter/testdata/proto/JSONFields.proto
+++ b/internal/converter/testdata/proto/JSONFields.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package samples;
+
+message JSONFields {
+    enum Topology {
+        FLAT             = 0;
+        NESTED_OBJECT    = 1;
+        NESTED_MESSAGE   = 2;
+        ARRAY_OF_TYPE    = 3;
+        ARRAY_OF_OBJECT  = 4;
+        ARRAY_OF_MESSAGE = 5;
+    }
+
+    string name       = 1;
+    string timestamp  = 2 [json_name="time_stamp"];
+    int32 id          = 3 [json_name="identifier"];
+    float rating      = 4;
+    bool complete     = 5;
+    Topology topology = 6;
+}

--- a/internal/converter/testdata/proto/JSONFields.proto
+++ b/internal/converter/testdata/proto/JSONFields.proto
@@ -2,9 +2,9 @@ syntax = "proto3";
 package samples;
 
 message JSONFields {
-    string name       = 1;
-    string timestamp  = 2 [json_name="time_stamp"];
-    int32 id          = 3 [json_name="identifier"];
-    float rating      = 4;
-    bool complete     = 5;
+    string name      = 1;
+    string timestamp = 2;
+    int32 id         = 3 [json_name="identifier"];
+    float some_thing = 4 [json_name="someThing"];
+    bool complete    = 5;
 }

--- a/internal/converter/testdata/proto/JSONFields.proto
+++ b/internal/converter/testdata/proto/JSONFields.proto
@@ -2,19 +2,9 @@ syntax = "proto3";
 package samples;
 
 message JSONFields {
-    enum Topology {
-        FLAT             = 0;
-        NESTED_OBJECT    = 1;
-        NESTED_MESSAGE   = 2;
-        ARRAY_OF_TYPE    = 3;
-        ARRAY_OF_OBJECT  = 4;
-        ARRAY_OF_MESSAGE = 5;
-    }
-
     string name       = 1;
     string timestamp  = 2 [json_name="time_stamp"];
     int32 id          = 3 [json_name="identifier"];
     float rating      = 4;
     bool complete     = 5;
-    Topology topology = 6;
 }

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -474,9 +474,16 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msg *descr
 			return nil, err
 		}
 		c.logger.WithField("field_name", fieldDesc.GetName()).WithField("type", recursedJSONSchemaType.Type).Trace("Converted field")
-		jsonSchemaType.Properties.Set(fieldDesc.GetName(), recursedJSONSchemaType)
-		if c.UseProtoAndJSONFieldnames && fieldDesc.GetName() != fieldDesc.GetJsonName() {
+
+		// Figure out which field names we want to use:
+		switch {
+		case c.UseJSONFieldnamesOnly:
 			jsonSchemaType.Properties.Set(fieldDesc.GetJsonName(), recursedJSONSchemaType)
+		case c.UseProtoAndJSONFieldnames:
+			jsonSchemaType.Properties.Set(fieldDesc.GetName(), recursedJSONSchemaType)
+			jsonSchemaType.Properties.Set(fieldDesc.GetJsonName(), recursedJSONSchemaType)
+		default:
+			jsonSchemaType.Properties.Set(fieldDesc.GetName(), recursedJSONSchemaType)
 		}
 
 		// Look for required fields (either by proto2 required flag, or the AllFieldsRequired option):

--- a/jsonschemas/JSONFields.jsonschema
+++ b/jsonschemas/JSONFields.jsonschema
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "time_stamp": {
+            "type": "string"
+        },
+        "identifier": {
+            "type": "integer"
+        },
+        "rating": {
+            "type": "number"
+        },
+        "complete": {
+            "type": "boolean"
+        },
+        "topology": {
+            "enum": [
+                "FLAT",
+                0,
+                "NESTED_OBJECT",
+                1,
+                "NESTED_MESSAGE",
+                2,
+                "ARRAY_OF_TYPE",
+                3,
+                "ARRAY_OF_OBJECT",
+                4,
+                "ARRAY_OF_MESSAGE",
+                5
+            ],
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "integer"
+                }
+            ]
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}

--- a/jsonschemas/JSONFields.jsonschema
+++ b/jsonschemas/JSONFields.jsonschema
@@ -4,13 +4,13 @@
         "name": {
             "type": "string"
         },
-        "time_stamp": {
+        "timestamp": {
             "type": "string"
         },
         "identifier": {
             "type": "integer"
         },
-        "rating": {
+        "someThing": {
             "type": "number"
         },
         "complete": {

--- a/jsonschemas/JSONFields.jsonschema
+++ b/jsonschemas/JSONFields.jsonschema
@@ -15,6 +15,16 @@
         },
         "complete": {
             "type": "boolean"
+        },
+        "snakeNumb": {
+            "oneOf": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "type": "string"
+                }
+            ]
         }
     },
     "additionalProperties": true,


### PR DESCRIPTION
In response to https://github.com/chrusty/protoc-gen-jsonschema/issues/38, adding a new `json_fieldnames` option.

Covered:

- README
- Samples
- Option and implementation
- Unit test 