### PR TITLE
fix: fix npe on required array fields

### DIFF
--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -257,7 +257,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			jsonSchemaType.Type = gojsonschema.TYPE_ARRAY
 
 			// Build up the list of required fields:
-			if c.AllFieldsRequired {
+			if c.AllFieldsRequired && recursedJSONSchemaType.Properties != nil {
 				for _, property := range recursedJSONSchemaType.Properties.Keys() {
 					jsonSchemaType.Items.Required = append(jsonSchemaType.Items.Required, property)
 				}


### PR DESCRIPTION
Fixes NPE on required array fields.

I see a recent related PR fixed one code path. I had to patch with this fix (and that fix) for the generator to run against our protos.

Related: https://github.com/chrusty/protoc-gen-jsonschema/pull/42

ST:

```
- Setting up protoc plugin (chrusty/protoc-gen-jsonschema)
github.com/chrusty/protoc-gen-jsonschema/internal/converter
github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema
go: found github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema in github.com/chrusty/protoc-gen-jsonschema v0.0.0-20201030011557-8cf8bfec94d1
- Converting protos to JSON Schemas
  - google/events/firebase/database/v1
INFO[0000] Generating JSON-schema for MESSAGE            jsonschema_filename=ReferenceEventData.jsonschema msg_name=ReferenceEventData proto_filename=data.proto
  - google/events/firebase/auth/v1
WARN[0000] protoc-gen-jsonschema will create multiple MESSAGE schemas from one proto file  proto_filename=data.proto schemas=3
INFO[0000] Generating JSON-schema for MESSAGE            jsonschema_filename=AuthEventData.jsonschema msg_name=AuthEventData proto_filename=data.proto
INFO[0000] Generating JSON-schema for MESSAGE            jsonschema_filename=UserMetadata.jsonschema msg_name=UserMetadata proto_filename=data.proto
INFO[0000] Generating JSON-schema for MESSAGE            jsonschema_filename=UserInfo.jsonschema msg_name=UserInfo proto_filename=data.proto
  - google/events/firebase/remoteconfig/v1
WARN[0000] protoc-gen-jsonschema will create multiple MESSAGE schemas from one proto file  proto_filename=data.proto schemas=2
WARN[0000] protoc-gen-jsonschema will create multiple ENUM schemas from one proto file  proto_filename=data.proto schemas=2
INFO[0000] Generating JSON-schema for MESSAGE            jsonschema_filename=RemoteConfigEventData.jsonschema msg_name=RemoteConfigEventData proto_filename=data.proto
INFO[0000] Generating JSON-schema for MESSAGE            jsonschema_filename=RemoteConfigUser.jsonschema msg_name=RemoteConfigUser proto_filename=data.proto
  - google/events/firebase/analytics/v1
WARN[0000] protoc-gen-jsonschema will create multiple MESSAGE schemas from one proto file  proto_filename=data.proto schemas=11
INFO[0000] Generating JSON-schema for MESSAGE            jsonschema_filename=AnalyticsLogData.jsonschema msg_name=AnalyticsLogData proto_filename=data.proto
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1404d16]

goroutine 1 [running]:
github.com/iancoleman/orderedmap.(*OrderedMap).Keys(...)
        /Users/timmerman/go/src/github.com/iancoleman/orderedmap/orderedmap.go:94
github.com/chrusty/protoc-gen-jsonschema/internal/converter.(*Converter).convertField(0xc00019ff48, 0xc0001d7f20, 0xc0001ef280, 0xc0001e2700, 0xc00021e720, 0xc000222620, 0x0, 0x0)
        /Users/timmerman/go/src/github.com/chrusty/protoc-gen-jsonschema/internal/converter/types.go:279 +0x1096
github.com/chrusty/protoc-gen-jsonschema/internal/converter.(*Converter).recursiveConvertMessageType(0xc00019ff48, 0xc0001d7f20, 0xc0001e2700, 0xc0000aca80, 0x24, 0xc00021e720, 0x0, 0x203001, 0x30, 0x203000)
        /Users/timmerman/go/src/github.com/chrusty/protoc-gen-jsonschema/internal/converter/types.go:473 +0x41d
github.com/chrusty/protoc-gen-jsonschema/internal/converter.(*Converter).convertField(0xc00019ff48, 0xc0001d7f20, 0xc0001eee80, 0xc0001e2600, 0xc00021e720, 0xc00020b8e0, 0x0, 0x1)
        /Users/timmerman/go/src/github.com/chrusty/protoc-gen-jsonschema/internal/converter/types.go:226 +0xb94
github.com/chrusty/protoc-gen-jsonschema/internal/converter.(*Converter).recursiveConvertMessageType(0xc00019ff48, 0xc0001d7f20, 0xc0001e2600, 0xc0000aca80, 0x24, 0xc00021e720, 0x0, 0x203001, 0xaa, 0x203000)
        /Users/timmerman/go/src/github.com/chrusty/protoc-gen-jsonschema/internal/converter/types.go:473 +0x41d
github.com/chrusty/protoc-gen-jsonschema/internal/converter.(*Converter).convertField(0xc00019ff48, 0xc0001d7f20, 0xc0001eea00, 0xc0001e2500, 0xc00021e720, 0xc000200e60, 0x1, 0x2)
        /Users/timmerman/go/src/github.com/chrusty/protoc-gen-jsonschema/internal/converter/types.go:226 +0xb94
github.com/chrusty/protoc-gen-jsonschema/internal/converter.(*Converter).recursiveConvertMessageType(0xc00019ff48, 0xc0001d7f20, 0xc0001e2500, 0xc0000aca80, 0x24, 0xc00021e720, 0x0, 0x1, 0x30, 0x14cecc0)
        /Users/timmerman/go/src/github.com/chrusty/protoc-gen-jsonschema/internal/converter/types.go:473 +0x41d
github.com/chrusty/protoc-gen-jsonschema/internal/converter.(*Converter).convertField(0xc00019ff48, 0xc0001d7f20, 0xc0001ee100, 0xc0001e2200, 0xc00021e720, 0xc000222230, 0x0, 0x0)
        /Users/timmerman/go/src/github.com/chrusty/protoc-gen-jsonschema/internal/converter/types.go:226 +0xb94
github.com/chrusty/protoc-gen-jsonschema/internal/converter.(*Converter).recursiveConvertMessageType(0xc00019ff48, 0xc0001d7f20, 0xc0001e2200, 0x0, 0x0, 0xc00021e720, 0xc00021e600, 0x0, 0x0, 0x0)
        /Users/timmerman/go/src/github.com/chrusty/protoc-gen-jsonschema/internal/converter/types.go:473 +0x41d
github.com/chrusty/protoc-gen-jsonschema/internal/converter.(*Converter).convertMessageType(0xc00019ff48, 0xc0001d7f20, 0xc0001e2200, 0x1, 0x1, 0xc00013bf80)
        /Users/timmerman/go/src/github.com/chrusty/protoc-gen-jsonschema/internal/converter/types.go:311 +0xba
github.com/chrusty/protoc-gen-jsonschema/internal/converter.(*Converter).convertFile(0xc00019ff48, 0xc0001e2000, 0xc00019fb40, 0x1, 0x1, 0xc00013bdc0, 0x15a5380)
        /Users/timmerman/go/src/github.com/chrusty/protoc-gen-jsonschema/internal/converter/converter.go:186 +0x707
github.com/chrusty/protoc-gen-jsonschema/internal/converter.(*Converter).convert(0xc00019ff48, 0xc00013a380, 0xc00019fdf8, 0x1, 0x1)
        /Users/timmerman/go/src/github.com/chrusty/protoc-gen-jsonschema/internal/converter/converter.go:234 +0x741
github.com/chrusty/protoc-gen-jsonschema/internal/converter.(*Converter).ConvertFrom(0xc00019ff48, 0x1593780, 0xc0000ae000, 0x1, 0x1, 0x2)
        /Users/timmerman/go/src/github.com/chrusty/protoc-gen-jsonschema/internal/converter/converter.go:61 +0x27e
main.main()
        /Users/timmerman/go/src/github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema/main.go:34 +0x1c5
--jsonschema_out: protoc-gen-jsonschema: Plugin failed with status code 2.
```