### PR TITLE
Fixing a bug that was still allowing nulls (even when allow_nulls wasn't enabled)

### DIFF
--- a/internal/converter/testdata/cyclical_reference.go
+++ b/internal/converter/testdata/cyclical_reference.go
@@ -6,8 +6,7 @@ const (
     "properties": {
         "foo": {
             "$ref": "samples.Foo",
-            "additionalProperties": true,
-            "type": "object"
+            "additionalProperties": true
         }
     },
     "additionalProperties": true,
@@ -33,8 +32,7 @@ const (
                                     },
                                     "foo": {
                                         "$ref": "samples.Foo",
-                                        "additionalProperties": true,
-                                        "type": "object"
+                                        "additionalProperties": true
                                     }
                                 },
                                 "additionalProperties": true,
@@ -78,8 +76,7 @@ const (
                                     },
                                     "foo": {
                                         "$ref": "Foo",
-                                        "additionalProperties": true,
-                                        "type": "object"
+                                        "additionalProperties": true
                                     }
                                 },
                                 "additionalProperties": true,
@@ -166,8 +163,7 @@ const (
                                     },
                                     "baz": {
                                         "$ref": "Baz",
-                                        "additionalProperties": true,
-                                        "type": "object"
+                                        "additionalProperties": true
                                     }
                                 },
                                 "additionalProperties": true,

--- a/internal/converter/testdata/enum_ception.go
+++ b/internal/converter/testdata/enum_ception.go
@@ -36,8 +36,7 @@ const EnumCeption = `{
         },
         "payload": {
             "$ref": "samples.PayloadMessage",
-            "additionalProperties": true,
-            "type": "object"
+            "additionalProperties": true
         },
         "payloads": {
             "items": {

--- a/internal/converter/testdata/google_value.go
+++ b/internal/converter/testdata/google_value.go
@@ -4,14 +4,8 @@ const GoogleValue = `{
     "$schema": "http://json-schema.org/draft-04/schema#",
     "properties": {
         "arg": {
-            "oneOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "object"
-                }
-            ]
+            "additionalProperties": true,
+            "type": "object"
         }
     },
     "additionalProperties": true,

--- a/internal/converter/testdata/wellknown.go
+++ b/internal/converter/testdata/wellknown.go
@@ -4,25 +4,13 @@ const WellKnown = `{
     "$schema": "http://json-schema.org/draft-04/schema#",
     "properties": {
         "string_value": {
-            "oneOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "string"
-                }
-            ]
+            "additionalProperties": true,
+            "type": "string"
         },
         "map_of_integers": {
             "additionalProperties": {
-                "oneOf": [
-                    {
-                        "type": "null"
-                    },
-                    {
-                        "type": "integer"
-                    }
-                ]
+                "additionalProperties": true,
+                "type": "integer"
             },
             "type": "object"
         },
@@ -34,14 +22,7 @@ const WellKnown = `{
         },
         "list_of_integers": {
             "items": {
-                "oneOf": [
-                    {
-                        "type": "null"
-                    },
-                    {
-                        "type": "integer"
-                    }
-                ]
+                "type": "integer"
             },
             "type": "array"
         }

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -391,29 +391,49 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msg *descr
 		schema.Type = ""
 		switch *msg.Name {
 		case "DoubleValue", "FloatValue":
-			schema.OneOf = []*jsonschema.Type{
-				{Type: gojsonschema.TYPE_NULL},
-				{Type: gojsonschema.TYPE_NUMBER},
+			if c.AllowNullValues {
+				schema.OneOf = []*jsonschema.Type{
+					{Type: gojsonschema.TYPE_NULL},
+					{Type: gojsonschema.TYPE_NUMBER},
+				}
+			} else {
+				schema.Type = gojsonschema.TYPE_NUMBER
 			}
 		case "Int32Value", "UInt32Value", "Int64Value", "UInt64Value":
-			schema.OneOf = []*jsonschema.Type{
-				{Type: gojsonschema.TYPE_NULL},
-				{Type: gojsonschema.TYPE_INTEGER},
+			if c.AllowNullValues {
+				schema.OneOf = []*jsonschema.Type{
+					{Type: gojsonschema.TYPE_NULL},
+					{Type: gojsonschema.TYPE_INTEGER},
+				}
+			} else {
+				schema.Type = gojsonschema.TYPE_INTEGER
 			}
 		case "BoolValue":
-			schema.OneOf = []*jsonschema.Type{
-				{Type: gojsonschema.TYPE_NULL},
-				{Type: gojsonschema.TYPE_BOOLEAN},
+			if c.AllowNullValues {
+				schema.OneOf = []*jsonschema.Type{
+					{Type: gojsonschema.TYPE_NULL},
+					{Type: gojsonschema.TYPE_BOOLEAN},
+				}
+			} else {
+				schema.Type = gojsonschema.TYPE_BOOLEAN
 			}
 		case "BytesValue", "StringValue":
-			schema.OneOf = []*jsonschema.Type{
-				{Type: gojsonschema.TYPE_NULL},
-				{Type: gojsonschema.TYPE_STRING},
+			if c.AllowNullValues {
+				schema.OneOf = []*jsonschema.Type{
+					{Type: gojsonschema.TYPE_NULL},
+					{Type: gojsonschema.TYPE_STRING},
+				}
+			} else {
+				schema.Type = gojsonschema.TYPE_STRING
 			}
 		case "Value":
-			schema.OneOf = []*jsonschema.Type{
-				{Type: gojsonschema.TYPE_NULL},
-				{Type: gojsonschema.TYPE_OBJECT},
+			if c.AllowNullValues {
+				schema.OneOf = []*jsonschema.Type{
+					{Type: gojsonschema.TYPE_NULL},
+					{Type: gojsonschema.TYPE_OBJECT},
+				}
+			} else {
+				schema.Type = gojsonschema.TYPE_OBJECT
 			}
 		}
 		return schema, nil

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -394,57 +394,37 @@ func (c *Converter) recursiveFindDuplicatedNestedMessages(curPkg *ProtoPackage, 
 }
 
 func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msg *descriptor.DescriptorProto, pkgName string, duplicatedMessages map[*descriptor.DescriptorProto]string, ignoreDuplicatedMessages bool) (*jsonschema.Type, error) {
+
+	// Handle google's well-known types:
 	if msg.Name != nil && wellKnownTypes[*msg.Name] && pkgName == ".google.protobuf" {
-		schema := &jsonschema.Type{}
-		schema.Type = ""
+		var schemaType string
 		switch *msg.Name {
 		case "DoubleValue", "FloatValue":
-			if c.AllowNullValues {
-				schema.OneOf = []*jsonschema.Type{
-					{Type: gojsonschema.TYPE_NULL},
-					{Type: gojsonschema.TYPE_NUMBER},
-				}
-			} else {
-				schema.Type = gojsonschema.TYPE_NUMBER
-			}
+			schemaType = gojsonschema.TYPE_NUMBER
 		case "Int32Value", "UInt32Value", "Int64Value", "UInt64Value":
-			if c.AllowNullValues {
-				schema.OneOf = []*jsonschema.Type{
-					{Type: gojsonschema.TYPE_NULL},
-					{Type: gojsonschema.TYPE_INTEGER},
-				}
-			} else {
-				schema.Type = gojsonschema.TYPE_INTEGER
-			}
+			schemaType = gojsonschema.TYPE_INTEGER
 		case "BoolValue":
-			if c.AllowNullValues {
-				schema.OneOf = []*jsonschema.Type{
-					{Type: gojsonschema.TYPE_NULL},
-					{Type: gojsonschema.TYPE_BOOLEAN},
-				}
-			} else {
-				schema.Type = gojsonschema.TYPE_BOOLEAN
-			}
+			schemaType = gojsonschema.TYPE_BOOLEAN
 		case "BytesValue", "StringValue":
-			if c.AllowNullValues {
-				schema.OneOf = []*jsonschema.Type{
-					{Type: gojsonschema.TYPE_NULL},
-					{Type: gojsonschema.TYPE_STRING},
-				}
-			} else {
-				schema.Type = gojsonschema.TYPE_STRING
-			}
+			schemaType = gojsonschema.TYPE_STRING
 		case "Value":
-			if c.AllowNullValues {
-				schema.OneOf = []*jsonschema.Type{
-					{Type: gojsonschema.TYPE_NULL},
-					{Type: gojsonschema.TYPE_OBJECT},
-				}
-			} else {
-				schema.Type = gojsonschema.TYPE_OBJECT
-			}
+			schemaType = gojsonschema.TYPE_OBJECT
 		}
-		return schema, nil
+
+		// If we're allowing nulls then prepare a OneOf:
+		if c.AllowNullValues {
+			return &jsonschema.Type{
+				OneOf: []*jsonschema.Type{
+					{Type: gojsonschema.TYPE_NULL},
+					{Type: schemaType},
+				},
+			}, nil
+		}
+
+		// Otherwise just return this simple type:
+		return &jsonschema.Type{
+			Type: schemaType,
+		}, nil
 	}
 
 	if refName, ok := duplicatedMessages[msg]; ok && !ignoreDuplicatedMessages {

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -251,12 +251,20 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 				}
 			}
 
-		// Objects:
+		// Not maps, not arrays:
 		default:
+
+			// If we've got optional types then just take those:
 			if recursedJSONSchemaType.OneOf != nil {
 				return recursedJSONSchemaType, nil
 			}
 
+			// If we're not an object then set the type from whatever we recursed:
+			if recursedJSONSchemaType.Type != gojsonschema.TYPE_OBJECT {
+				jsonSchemaType.Type = recursedJSONSchemaType.Type
+			}
+
+			// Assume the attrbutes of the recursed value:
 			jsonSchemaType.Properties = recursedJSONSchemaType.Properties
 			jsonSchemaType.Ref = recursedJSONSchemaType.Ref
 			jsonSchemaType.Required = recursedJSONSchemaType.Required


### PR DESCRIPTION
This addresses https://github.com/chrusty/protoc-gen-jsonschema/issues/43, but hopefully doesn't cause any issues for others. The result is a bit less cruft in the generated protos.

- Well-known types now adhere to "allow_nulls=false"
- Unit tests had to be updated

@grant and @pavolloffay what do you make of this?