### PR TITLE
int64 should always be string

### DIFF
--- a/internal/converter/testdata/array_of_primitives.go
+++ b/internal/converter/testdata/array_of_primitives.go
@@ -37,9 +37,6 @@ const ArrayOfPrimitives = `{
             "items": {
                 "oneOf": [
                     {
-                        "type": "integer"
-                    },
-                    {
                         "type": "string"
                     },
                     {
@@ -78,9 +75,6 @@ const ArrayOfPrimitives = `{
         },
         "big_number": {
             "oneOf": [
-                {
-                    "type": "integer"
-                },
                 {
                     "type": "string"
                 },
@@ -138,9 +132,6 @@ const ArrayOfPrimitivesDouble = `{
             "items": {
                 "oneOf": [
                     {
-                        "type": "integer"
-                    },
-                    {
                         "type": "string"
                     },
                     {
@@ -180,9 +171,6 @@ const ArrayOfPrimitivesDouble = `{
         "big_number": {
             "oneOf": [
                 {
-                    "type": "integer"
-                },
-                {
                     "type": "string"
                 },
                 {
@@ -192,9 +180,6 @@ const ArrayOfPrimitivesDouble = `{
         },
         "bigNumber": {
             "oneOf": [
-                {
-                    "type": "integer"
-                },
                 {
                     "type": "string"
                 },

--- a/internal/converter/testdata/json_fields.go
+++ b/internal/converter/testdata/json_fields.go
@@ -19,14 +19,7 @@ const JSONFields = `{
             "type": "boolean"
         },
         "snakeNumb": {
-            "oneOf": [
-                {
-                    "type": "integer"
-                },
-                {
-                    "type": "string"
-                }
-            ]
+            "type": "string"
         }
     },
     "additionalProperties": true,

--- a/internal/converter/testdata/message_kind_12.go
+++ b/internal/converter/testdata/message_kind_12.go
@@ -181,14 +181,7 @@ const MessageKind12 = `{
                     "type": "boolean"
                 },
                 "baz": {
-                    "oneOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
+                    "type": "string"
                 }
             },
             "additionalProperties": true,

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -109,12 +109,17 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		descriptor.FieldDescriptorProto_TYPE_FIXED64,
 		descriptor.FieldDescriptorProto_TYPE_SFIXED64,
 		descriptor.FieldDescriptorProto_TYPE_SINT64:
-		jsonSchemaType.OneOf = append(jsonSchemaType.OneOf, &jsonschema.Type{Type: gojsonschema.TYPE_INTEGER})
-		if !c.DisallowBigIntsAsStrings {
-			jsonSchemaType.OneOf = append(jsonSchemaType.OneOf, &jsonschema.Type{Type: gojsonschema.TYPE_STRING})
-		}
 		if c.AllowNullValues {
-			jsonSchemaType.OneOf = append(jsonSchemaType.OneOf, &jsonschema.Type{Type: gojsonschema.TYPE_NULL})
+			jsonSchemaType.OneOf = []*jsonschema.Type{
+				{Type: gojsonschema.TYPE_STRING},
+				{Type: gojsonschema.TYPE_NULL},
+			}
+		} else {
+			jsonSchemaType.Type = gojsonschema.TYPE_STRING
+		}
+
+		if c.DisallowBigIntsAsStrings {
+			jsonSchemaType.Type = gojsonschema.TYPE_INTEGER
 		}
 
 	case descriptor.FieldDescriptorProto_TYPE_STRING,


### PR DESCRIPTION
OneOf was causing issues for some users, and it was an exception only in place for int64. So now they will be represented as a string, unless the `disallow_bigints_as_strings` option is used.

Note: OneOf will still be used if the `allow_null_values` option is enabled.