### PR TITLE
Mark bytes fields as binary

### DIFF
--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -122,6 +122,11 @@ func configureSampleProtos() map[string]sampleProto {
 			FilesToGenerate:    []string{"ArrayOfPrimitives.proto"},
 			ProtoFileName:      "ArrayOfPrimitives.proto",
 		},
+		"BytesPayload": {
+			ExpectedJSONSchema: []string{testdata.BytesPayload},
+			FilesToGenerate:    []string{"BytesPayload.proto"},
+			ProtoFileName:      "BytesPayload.proto",
+		},
 		"ArrayOfPrimitivesDouble": {
 			AllowNullValues:           true,
 			ExpectedJSONSchema:        []string{testdata.ArrayOfPrimitivesDouble},

--- a/internal/converter/testdata/bytes_payload.go
+++ b/internal/converter/testdata/bytes_payload.go
@@ -1,0 +1,17 @@
+package testdata
+
+const BytesPayload = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "description": {
+            "type": "string"
+        },
+        "payload": {
+            "type": "string",
+            "format": "binary",
+            "binaryEncoding": "base64"
+        }
+    },
+    "additionalProperties": true,
+    "type": "object"
+}`

--- a/internal/converter/testdata/proto/BytesPayload.proto
+++ b/internal/converter/testdata/proto/BytesPayload.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package samples;
+
+message BytesPayload {
+    string description = 1;
+    bytes payload      = 2;
+}

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -122,8 +122,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			jsonSchemaType.Type = gojsonschema.TYPE_INTEGER
 		}
 
-	case descriptor.FieldDescriptorProto_TYPE_STRING,
-		descriptor.FieldDescriptorProto_TYPE_BYTES:
+	case descriptor.FieldDescriptorProto_TYPE_STRING:
 		if c.AllowNullValues {
 			jsonSchemaType.OneOf = []*jsonschema.Type{
 				{Type: gojsonschema.TYPE_NULL},
@@ -131,6 +130,17 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			}
 		} else {
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
+		}
+
+	case descriptor.FieldDescriptorProto_TYPE_BYTES:
+		if c.AllowNullValues {
+			jsonSchemaType.OneOf = []*jsonschema.Type{
+				{Type: gojsonschema.TYPE_NULL},
+				{Type: gojsonschema.TYPE_STRING},
+			}
+		} else {
+			jsonSchemaType.Type = gojsonschema.TYPE_STRING
+			jsonSchemaType.Format = "binary"
 		}
 
 	case descriptor.FieldDescriptorProto_TYPE_ENUM:

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -141,6 +141,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		} else {
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
 			jsonSchemaType.Format = "binary"
+			jsonSchemaType.BinaryEncoding = "base64"
 		}
 
 	case descriptor.FieldDescriptorProto_TYPE_ENUM:

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -136,7 +136,11 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		if c.AllowNullValues {
 			jsonSchemaType.OneOf = []*jsonschema.Type{
 				{Type: gojsonschema.TYPE_NULL},
-				{Type: gojsonschema.TYPE_STRING},
+				{
+					Type:           gojsonschema.TYPE_STRING,
+					Format:         "binary",
+					BinaryEncoding: "base64",
+				},
 			}
 		} else {
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING


### PR DESCRIPTION
- Bytes fields are now being marked with `format` = "binary"
- Bytes fields are also being marked with `binaryEncoding` = "base64"
- A simple test to confirm this works

@grant does this do what you need? How do you feel about the `binaryEncoding` part?