### PR TITLE
Hiding "oneOf" support behind a flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ samples:
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/Proto2Required.proto || echo "No messages found (Proto2Required.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/Proto2NestedMessage.proto || echo "No messages found (Proto2NestedMessage.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/GoogleValue.proto || echo "No messages found (GoogleValue.proto)"
-	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/OneOf.proto || echo "No messages found (OneOf.proto)"
+	@PATH=./bin:$$PATH; protoc --jsonschema_out=enforce_oneof:jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/OneOf.proto || echo "No messages found (OneOf.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=all_fields_required:jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/Proto2NestedObject.proto || echo "No messages found (Proto2NestedObject.proto)"
 	@PATH=./bin:$$PATH; protoc -I /usr/include --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/WellKnown.proto || echo "No messages found (WellKnown.proto)"
 	@PATH=./bin:$$PATH; protoc --jsonschema_out=jsonschemas --proto_path=${PROTO_PATH} ${PROTO_PATH}/NoPackage.proto

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ protoc \ # The protobuf compiler
 |`debug`| Enable debug logging |
 |`disallow_additional_properties`| Disallow additional properties in schema |
 |`disallow_bigints_as_strings`| Disallow big integers as strings |
+|`enforce_oneof` | Interpret Proto "oneOf" clauses |
 |`json_fieldnames` | Use JSON field names only |
 |`prefix_schema_files_with_package`| Prefix the output filename with package |
 |`proto_and_json_fieldnames`| Use proto and JSON field names |

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -22,16 +22,22 @@ const (
 
 // Converter is everything you need to convert protos to JSONSchemas:
 type Converter struct {
+	Flags          ConverterFlags
+	logger         *logrus.Logger
+	sourceInfo     *sourceCodeInfo
+	messageTargets []string
+}
+
+// ConverterFlags control the behaviour of the converter:
+type ConverterFlags struct {
 	AllFieldsRequired            bool
 	AllowNullValues              bool
 	DisallowAdditionalProperties bool
 	DisallowBigIntsAsStrings     bool
+	EnforceOneOf                 bool
 	PrefixSchemaFilesWithPackage bool
 	UseJSONFieldnamesOnly        bool
-	UseProtoAndJSONFieldnames    bool
-	logger                       *logrus.Logger
-	sourceInfo                   *sourceCodeInfo
-	messageTargets               []string
+	UseProtoAndJSONFieldNames    bool
 }
 
 // New returns a configured *Converter:
@@ -65,21 +71,21 @@ func (c *Converter) parseGeneratorParameters(parameters string) {
 	for _, parameter := range strings.Split(parameters, ",") {
 		switch parameter {
 		case "all_fields_required":
-			c.AllFieldsRequired = true
+			c.Flags.AllFieldsRequired = true
 		case "allow_null_values":
-			c.AllowNullValues = true
+			c.Flags.AllowNullValues = true
 		case "debug":
 			c.logger.SetLevel(logrus.DebugLevel)
 		case "disallow_additional_properties":
-			c.DisallowAdditionalProperties = true
+			c.Flags.DisallowAdditionalProperties = true
 		case "disallow_bigints_as_strings":
-			c.DisallowBigIntsAsStrings = true
+			c.Flags.DisallowBigIntsAsStrings = true
 		case "json_fieldnames":
-			c.UseJSONFieldnamesOnly = true
+			c.Flags.UseJSONFieldnamesOnly = true
 		case "prefix_schema_files_with_package":
-			c.PrefixSchemaFilesWithPackage = true
+			c.Flags.PrefixSchemaFilesWithPackage = true
 		case "proto_and_json_fieldnames":
-			c.UseProtoAndJSONFieldnames = true
+			c.Flags.UseProtoAndJSONFieldNames = true
 		}
 
 		// look for specific message targets
@@ -249,7 +255,7 @@ func (c *Converter) convert(req *plugin.CodeGeneratorRequest) (*plugin.CodeGener
 }
 
 func (c *Converter) generateSchemaFilename(file *descriptor.FileDescriptorProto, protoName string) string {
-	if c.PrefixSchemaFilesWithPackage {
+	if c.Flags.PrefixSchemaFilesWithPackage {
 		return fmt.Sprintf("%s/%s.jsonschema", file.GetPackage(), protoName)
 	}
 	return fmt.Sprintf("%s.jsonschema", protoName)

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -80,6 +80,8 @@ func (c *Converter) parseGeneratorParameters(parameters string) {
 			c.Flags.DisallowAdditionalProperties = true
 		case "disallow_bigints_as_strings":
 			c.Flags.DisallowBigIntsAsStrings = true
+		case "enforce_oneof":
+			c.Flags.EnforceOneOf = true
 		case "json_fieldnames":
 			c.Flags.UseJSONFieldnamesOnly = true
 		case "prefix_schema_files_with_package":

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -22,15 +22,11 @@ const (
 )
 
 type sampleProto struct {
-	AllFieldsRequired            bool
-	AllowNullValues              bool
-	ExpectedJSONSchema           []string
-	FilesToGenerate              []string
-	PrefixSchemaFilesWithPackage bool
-	ProtoFileName                string
-	UseJSONFieldnamesOnly        bool
-	UseProtoAndJSONFieldNames    bool
-	TargetedMessages             []string
+	Flags              ConverterFlags
+	ExpectedJSONSchema []string
+	FilesToGenerate    []string
+	ProtoFileName      string
+	TargetedMessages   []string
 }
 
 func TestGenerateJsonSchema(t *testing.T) {
@@ -56,11 +52,7 @@ func testConvertSampleProto(t *testing.T, sampleProto sampleProto) {
 
 	// Use the logger to make a Converter:
 	protoConverter := New(logger)
-	protoConverter.AllFieldsRequired = sampleProto.AllFieldsRequired
-	protoConverter.AllowNullValues = sampleProto.AllowNullValues
-	protoConverter.UseJSONFieldnamesOnly = sampleProto.UseJSONFieldnamesOnly
-	protoConverter.UseProtoAndJSONFieldnames = sampleProto.UseProtoAndJSONFieldNames
-	protoConverter.PrefixSchemaFilesWithPackage = sampleProto.PrefixSchemaFilesWithPackage
+	protoConverter.Flags = sampleProto.Flags
 
 	// Open the sample proto file:
 	sampleProtoFileName := fmt.Sprintf("%v/%v", sampleProtoDirectory, sampleProto.ProtoFileName)
@@ -95,7 +87,7 @@ func testConvertSampleProto(t *testing.T, sampleProto sampleProto) {
 	}
 
 	// Check for the correct prefix:
-	if protoConverter.PrefixSchemaFilesWithPackage {
+	if protoConverter.Flags.PrefixSchemaFilesWithPackage {
 		assert.Contains(t, response.File[0].GetName(), "samples")
 	} else {
 		assert.NotContains(t, response.File[0].GetName(), "samples")
@@ -105,19 +97,18 @@ func testConvertSampleProto(t *testing.T, sampleProto sampleProto) {
 func configureSampleProtos() map[string]sampleProto {
 	return map[string]sampleProto{
 		"ArrayOfMessages": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.PayloadMessage, testdata.ArrayOfMessages},
 			FilesToGenerate:    []string{"ArrayOfMessages.proto", "PayloadMessage.proto"},
 			ProtoFileName:      "ArrayOfMessages.proto",
 		},
 		"ArrayOfObjects": {
-			AllowNullValues:    true,
+			Flags:              ConverterFlags{AllowNullValues: true},
 			ExpectedJSONSchema: []string{testdata.ArrayOfObjects},
 			FilesToGenerate:    []string{"ArrayOfObjects.proto"},
 			ProtoFileName:      "ArrayOfObjects.proto",
 		},
 		"ArrayOfPrimitives": {
-			AllowNullValues:    true,
+			Flags:              ConverterFlags{AllowNullValues: true},
 			ExpectedJSONSchema: []string{testdata.ArrayOfPrimitives},
 			FilesToGenerate:    []string{"ArrayOfPrimitives.proto"},
 			ProtoFileName:      "ArrayOfPrimitives.proto",
@@ -128,86 +119,75 @@ func configureSampleProtos() map[string]sampleProto {
 			ProtoFileName:      "BytesPayload.proto",
 		},
 		"ArrayOfPrimitivesDouble": {
-			AllowNullValues:           true,
-			ExpectedJSONSchema:        []string{testdata.ArrayOfPrimitivesDouble},
-			FilesToGenerate:           []string{"ArrayOfPrimitives.proto"},
-			ProtoFileName:             "ArrayOfPrimitives.proto",
-			UseProtoAndJSONFieldNames: true,
+			Flags: ConverterFlags{
+				AllowNullValues:           true,
+				UseProtoAndJSONFieldNames: true,
+			},
+			ExpectedJSONSchema: []string{testdata.ArrayOfPrimitivesDouble},
+			FilesToGenerate:    []string{"ArrayOfPrimitives.proto"},
+			ProtoFileName:      "ArrayOfPrimitives.proto",
 		},
 		"EnumNestedReference": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.EnumNestedReference},
 			FilesToGenerate:    []string{"EnumNestedReference.proto"},
 			ProtoFileName:      "EnumNestedReference.proto",
 		},
 		"EnumWithMessage": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.EnumWithMessage},
 			FilesToGenerate:    []string{"EnumWithMessage.proto"},
 			ProtoFileName:      "EnumWithMessage.proto",
 		},
 		"EnumImport": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.EnumImport},
 			FilesToGenerate:    []string{"ImportEnum.proto"},
 			ProtoFileName:      "ImportEnum.proto",
 		},
 		"EnumCeption": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.PayloadMessage, testdata.ImportedEnum, testdata.EnumCeption},
 			FilesToGenerate:    []string{"Enumception.proto", "PayloadMessage.proto", "ImportedEnum.proto"},
 			ProtoFileName:      "Enumception.proto",
 		},
 		"ImportedEnum": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.ImportedEnum},
 			FilesToGenerate:    []string{"ImportedEnum.proto"},
 			ProtoFileName:      "ImportedEnum.proto",
 		},
 		"NestedMessage": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.PayloadMessage, testdata.NestedMessage},
 			FilesToGenerate:    []string{"NestedMessage.proto", "PayloadMessage.proto"},
 			ProtoFileName:      "NestedMessage.proto",
 		},
 		"NestedObject": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.NestedObject},
 			FilesToGenerate:    []string{"NestedObject.proto"},
 			ProtoFileName:      "NestedObject.proto",
 		},
 		"PayloadMessage": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.PayloadMessage},
 			FilesToGenerate:    []string{"PayloadMessage.proto"},
 			ProtoFileName:      "PayloadMessage.proto",
 		},
 		"SeveralEnums": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.FirstEnum, testdata.SecondEnum},
 			FilesToGenerate:    []string{"SeveralEnums.proto"},
 			ProtoFileName:      "SeveralEnums.proto",
 		},
 		"SeveralMessages": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.FirstMessage, testdata.SecondMessage},
 			FilesToGenerate:    []string{"SeveralMessages.proto"},
 			ProtoFileName:      "SeveralMessages.proto",
 		},
 		"ArrayOfEnums": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.ArrayOfEnums},
 			FilesToGenerate:    []string{"ArrayOfEnums.proto"},
 			ProtoFileName:      "ArrayOfEnums.proto",
 		},
 		"Maps": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.Maps},
 			FilesToGenerate:    []string{"Maps.proto"},
 			ProtoFileName:      "Maps.proto",
 		},
 		"Comments": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.MessageWithComments},
 			FilesToGenerate:    []string{"MessageWithComments.proto"},
 			ProtoFileName:      "MessageWithComments.proto",
@@ -238,10 +218,10 @@ func configureSampleProtos() map[string]sampleProto {
 			ProtoFileName:      "NoPackage.proto",
 		},
 		"PackagePrefix": {
-			ExpectedJSONSchema:           []string{testdata.Timestamp},
-			FilesToGenerate:              []string{"Timestamp.proto"},
-			ProtoFileName:                "Timestamp.proto",
-			PrefixSchemaFilesWithPackage: true,
+			Flags:              ConverterFlags{PrefixSchemaFilesWithPackage: true},
+			ExpectedJSONSchema: []string{testdata.Timestamp},
+			FilesToGenerate:    []string{"Timestamp.proto"},
+			ProtoFileName:      "Timestamp.proto",
 		},
 		"Proto2Required": {
 			ExpectedJSONSchema: []string{testdata.Proto2Required},
@@ -249,21 +229,18 @@ func configureSampleProtos() map[string]sampleProto {
 			ProtoFileName:      "Proto2Required.proto",
 		},
 		"AllRequired": {
-			AllFieldsRequired:  true,
-			AllowNullValues:    false,
+			Flags:              ConverterFlags{AllFieldsRequired: true},
 			ExpectedJSONSchema: []string{testdata.PayloadMessage2},
 			FilesToGenerate:    []string{"PayloadMessage2.proto"},
 			ProtoFileName:      "PayloadMessage2.proto",
 		},
 		"Proto2NestedMessage": {
-			AllowNullValues:    false,
 			ExpectedJSONSchema: []string{testdata.Proto2PayloadMessage, testdata.Proto2NestedMessage},
 			FilesToGenerate:    []string{"Proto2PayloadMessage.proto", "Proto2NestedMessage.proto"},
 			ProtoFileName:      "Proto2NestedMessage.proto",
 		},
 		"Proto2NestedObject": {
-			AllFieldsRequired:  true,
-			AllowNullValues:    false,
+			Flags:              ConverterFlags{AllFieldsRequired: true},
 			ExpectedJSONSchema: []string{testdata.Proto2NestedObject},
 			FilesToGenerate:    []string{"Proto2NestedObject.proto"},
 			ProtoFileName:      "Proto2NestedObject.proto",
@@ -280,12 +257,13 @@ func configureSampleProtos() map[string]sampleProto {
 			ProtoFileName:      "GoogleValue.proto",
 		},
 		"JSONFields": {
-			ExpectedJSONSchema:    []string{testdata.JSONFields},
-			FilesToGenerate:       []string{"JSONFields.proto"},
-			ProtoFileName:         "JSONFields.proto",
-			UseJSONFieldnamesOnly: true,
+			Flags:              ConverterFlags{UseJSONFieldnamesOnly: true},
+			ExpectedJSONSchema: []string{testdata.JSONFields},
+			FilesToGenerate:    []string{"JSONFields.proto"},
+			ProtoFileName:      "JSONFields.proto",
 		},
 		"OneOf": {
+			Flags:              ConverterFlags{EnforceOneOf: true},
 			ExpectedJSONSchema: []string{testdata.OneOf},
 			FilesToGenerate:    []string{"OneOf.proto"},
 			ProtoFileName:      "OneOf.proto",

--- a/internal/converter/testdata/message_kind_11.go
+++ b/internal/converter/testdata/message_kind_11.go
@@ -108,23 +108,6 @@ const MessageKind11 = `{
         }
     },
     "additionalProperties": true,
-    "type": "object",
-    "oneOf": [
-        {
-            "required": [
-                "kind2"
-            ]
-        },
-        {
-            "required": [
-                "kind3"
-            ]
-        },
-        {
-            "required": [
-                "kind4"
-            ]
-        }
-    ]
+    "type": "object"
 }
 `

--- a/internal/converter/testdata/message_kind_12.go
+++ b/internal/converter/testdata/message_kind_12.go
@@ -7,7 +7,6 @@ const MessageKind12 = `{
             "type": "string"
         },
         "f": {
-            "$schema": "http://json-schema.org/draft-04/schema#",
             "properties": {
                 "name": {
                     "type": "string"
@@ -114,24 +113,7 @@ const MessageKind12 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object",
-            "oneOf": [
-                {
-                    "required": [
-                        "kind2"
-                    ]
-                },
-                {
-                    "required": [
-                        "kind3"
-                    ]
-                },
-                {
-                    "required": [
-                        "kind4"
-                    ]
-                }
-            ]
+            "type": "object"
         },
         "kind5": {
             "properties": {
@@ -207,23 +189,6 @@ const MessageKind12 = `{
         }
     },
     "additionalProperties": true,
-    "type": "object",
-    "oneOf": [
-        {
-            "required": [
-                "kind5"
-            ]
-        },
-        {
-            "required": [
-                "kind6"
-            ]
-        },
-        {
-            "required": [
-                "kind7"
-            ]
-        }
-    ]
+    "type": "object"
 }
 `

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -492,7 +492,7 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msg *descr
 		c.logger.WithField("field_name", fieldDesc.GetName()).WithField("type", recursedJSONSchemaType.Type).Trace("Converted field")
 
 		// If this field is part of a OneOf declaration then build that here:
-		if fieldDesc.OneofIndex != nil {
+		if c.Flags.EnforceOneOf && fieldDesc.OneofIndex != nil {
 			jsonSchemaType.OneOf = append(jsonSchemaType.OneOf, &jsonschema.Type{Required: []string{fieldDesc.GetName()}})
 		}
 

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -81,7 +81,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 	switch desc.GetType() {
 	case descriptor.FieldDescriptorProto_TYPE_DOUBLE,
 		descriptor.FieldDescriptorProto_TYPE_FLOAT:
-		if c.AllowNullValues {
+		if c.Flags.AllowNullValues {
 			jsonSchemaType.OneOf = []*jsonschema.Type{
 				{Type: gojsonschema.TYPE_NULL},
 				{Type: gojsonschema.TYPE_NUMBER},
@@ -95,7 +95,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		descriptor.FieldDescriptorProto_TYPE_FIXED32,
 		descriptor.FieldDescriptorProto_TYPE_SFIXED32,
 		descriptor.FieldDescriptorProto_TYPE_SINT32:
-		if c.AllowNullValues {
+		if c.Flags.AllowNullValues {
 			jsonSchemaType.OneOf = []*jsonschema.Type{
 				{Type: gojsonschema.TYPE_NULL},
 				{Type: gojsonschema.TYPE_INTEGER},
@@ -109,7 +109,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		descriptor.FieldDescriptorProto_TYPE_FIXED64,
 		descriptor.FieldDescriptorProto_TYPE_SFIXED64,
 		descriptor.FieldDescriptorProto_TYPE_SINT64:
-		if c.AllowNullValues {
+		if c.Flags.AllowNullValues {
 			jsonSchemaType.OneOf = []*jsonschema.Type{
 				{Type: gojsonschema.TYPE_STRING},
 				{Type: gojsonschema.TYPE_NULL},
@@ -118,12 +118,12 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
 		}
 
-		if c.DisallowBigIntsAsStrings {
+		if c.Flags.DisallowBigIntsAsStrings {
 			jsonSchemaType.Type = gojsonschema.TYPE_INTEGER
 		}
 
 	case descriptor.FieldDescriptorProto_TYPE_STRING:
-		if c.AllowNullValues {
+		if c.Flags.AllowNullValues {
 			jsonSchemaType.OneOf = []*jsonschema.Type{
 				{Type: gojsonschema.TYPE_NULL},
 				{Type: gojsonschema.TYPE_STRING},
@@ -133,7 +133,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		}
 
 	case descriptor.FieldDescriptorProto_TYPE_BYTES:
-		if c.AllowNullValues {
+		if c.Flags.AllowNullValues {
 			jsonSchemaType.OneOf = []*jsonschema.Type{
 				{Type: gojsonschema.TYPE_NULL},
 				{
@@ -151,7 +151,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 	case descriptor.FieldDescriptorProto_TYPE_ENUM:
 		jsonSchemaType.OneOf = append(jsonSchemaType.OneOf, &jsonschema.Type{Type: gojsonschema.TYPE_STRING})
 		jsonSchemaType.OneOf = append(jsonSchemaType.OneOf, &jsonschema.Type{Type: gojsonschema.TYPE_INTEGER})
-		if c.AllowNullValues {
+		if c.Flags.AllowNullValues {
 			jsonSchemaType.OneOf = append(jsonSchemaType.OneOf, &jsonschema.Type{Type: gojsonschema.TYPE_NULL})
 		}
 
@@ -169,7 +169,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		}
 
 	case descriptor.FieldDescriptorProto_TYPE_BOOL:
-		if c.AllowNullValues {
+		if c.Flags.AllowNullValues {
 			jsonSchemaType.OneOf = []*jsonschema.Type{
 				{Type: gojsonschema.TYPE_NULL},
 				{Type: gojsonschema.TYPE_BOOLEAN},
@@ -210,7 +210,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			jsonSchemaType.Items.OneOf = jsonSchemaType.OneOf
 		}
 
-		if c.AllowNullValues {
+		if c.Flags.AllowNullValues {
 			jsonSchemaType.OneOf = []*jsonschema.Type{
 				{Type: gojsonschema.TYPE_NULL},
 				{Type: gojsonschema.TYPE_ARRAY},
@@ -265,7 +265,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			jsonSchemaType.Type = gojsonschema.TYPE_ARRAY
 
 			// Build up the list of required fields:
-			if c.AllFieldsRequired && recursedJSONSchemaType.Properties != nil {
+			if c.Flags.AllFieldsRequired && recursedJSONSchemaType.Properties != nil {
 				for _, property := range recursedJSONSchemaType.Properties.Keys() {
 					jsonSchemaType.Items.Required = append(jsonSchemaType.Items.Required, property)
 				}
@@ -290,7 +290,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			jsonSchemaType.Required = recursedJSONSchemaType.Required
 
 			// Build up the list of required fields:
-			if c.AllFieldsRequired && recursedJSONSchemaType.Properties != nil {
+			if c.Flags.AllFieldsRequired && recursedJSONSchemaType.Properties != nil {
 				for _, property := range recursedJSONSchemaType.Properties.Keys() {
 					jsonSchemaType.Required = append(jsonSchemaType.Required, property)
 				}
@@ -298,7 +298,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		}
 
 		// Optionally allow NULL values:
-		if c.AllowNullValues {
+		if c.Flags.AllowNullValues {
 			jsonSchemaType.OneOf = []*jsonschema.Type{
 				{Type: gojsonschema.TYPE_NULL},
 				{Type: jsonSchemaType.Type},
@@ -350,7 +350,7 @@ func (c *Converter) convertMessageType(curPkg *ProtoPackage, msg *descriptor.Des
 
 	// Look for required fields (either by proto2 required flag, or the AllFieldsRequired option):
 	for _, fieldDesc := range msg.GetField() {
-		if c.AllFieldsRequired || fieldDesc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_REQUIRED {
+		if c.Flags.AllFieldsRequired || fieldDesc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_REQUIRED {
 			newJSONSchema.Required = append(newJSONSchema.Required, fieldDesc.GetName())
 		}
 	}
@@ -438,7 +438,7 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msg *descr
 		}
 
 		// If we're allowing nulls then prepare a OneOf:
-		if c.AllowNullValues {
+		if c.Flags.AllowNullValues {
 			wellKnownSchema.OneOf = append(wellKnownSchema.OneOf, &jsonschema.Type{Type: gojsonschema.TYPE_NULL}, &jsonschema.Type{Type: wellKnownSchema.Type})
 			return wellKnownSchema, nil
 		}
@@ -466,7 +466,7 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msg *descr
 	}
 
 	// Optionally allow NULL values:
-	if c.AllowNullValues {
+	if c.Flags.AllowNullValues {
 		jsonSchemaType.OneOf = []*jsonschema.Type{
 			{Type: gojsonschema.TYPE_NULL},
 			{Type: gojsonschema.TYPE_OBJECT},
@@ -476,7 +476,7 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msg *descr
 	}
 
 	// disallowAdditionalProperties will prevent validation where extra fields are found (outside of the schema):
-	if c.DisallowAdditionalProperties {
+	if c.Flags.DisallowAdditionalProperties {
 		jsonSchemaType.AdditionalProperties = []byte("false")
 	} else {
 		jsonSchemaType.AdditionalProperties = []byte("true")
@@ -498,9 +498,9 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msg *descr
 
 		// Figure out which field names we want to use:
 		switch {
-		case c.UseJSONFieldnamesOnly:
+		case c.Flags.UseJSONFieldnamesOnly:
 			jsonSchemaType.Properties.Set(fieldDesc.GetJsonName(), recursedJSONSchemaType)
-		case c.UseProtoAndJSONFieldnames:
+		case c.Flags.UseProtoAndJSONFieldNames:
 			jsonSchemaType.Properties.Set(fieldDesc.GetName(), recursedJSONSchemaType)
 			jsonSchemaType.Properties.Set(fieldDesc.GetJsonName(), recursedJSONSchemaType)
 		default:

--- a/jsonschemas/MessageKind11.jsonschema
+++ b/jsonschemas/MessageKind11.jsonschema
@@ -106,22 +106,5 @@
         }
     },
     "additionalProperties": true,
-    "type": "object",
-    "oneOf": [
-        {
-            "required": [
-                "kind2"
-            ]
-        },
-        {
-            "required": [
-                "kind3"
-            ]
-        },
-        {
-            "required": [
-                "kind4"
-            ]
-        }
-    ]
+    "type": "object"
 }

--- a/jsonschemas/MessageKind12.jsonschema
+++ b/jsonschemas/MessageKind12.jsonschema
@@ -5,7 +5,6 @@
             "type": "string"
         },
         "f": {
-            "$schema": "http://json-schema.org/draft-04/schema#",
             "properties": {
                 "name": {
                     "type": "string"
@@ -112,24 +111,7 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object",
-            "oneOf": [
-                {
-                    "required": [
-                        "kind2"
-                    ]
-                },
-                {
-                    "required": [
-                        "kind3"
-                    ]
-                },
-                {
-                    "required": [
-                        "kind4"
-                    ]
-                }
-            ]
+            "type": "object"
         },
         "kind5": {
             "properties": {
@@ -205,22 +187,5 @@
         }
     },
     "additionalProperties": true,
-    "type": "object",
-    "oneOf": [
-        {
-            "required": [
-                "kind5"
-            ]
-        },
-        {
-            "required": [
-                "kind6"
-            ]
-        },
-        {
-            "required": [
-                "kind7"
-            ]
-        }
-    ]
+    "type": "object"
 }


### PR DESCRIPTION
This PR introduces an optional flag to enable the `OneOf` logic which was introduced in a previous PR.
- [x] Flag
- [x] README
- [x] Samples
- [X] Tests

Also took the opportunity to introduce an explicit config struct for all of these flags, which makes configuring the unit tests a bit less clunky.