### PR TITLE
Format and pattern (regex) for duration

### DIFF
--- a/internal/converter/testdata/wellknown.go
+++ b/internal/converter/testdata/wellknown.go
@@ -28,9 +28,10 @@ const WellKnown = `{
             "type": "array"
         },
         "duration": {
-            "additionalProperties": true,
+            "pattern": "^([0-9]+\\.?[0-9]*|\\.[0-9]+)(ns|ms|s|m|h|d)$",
             "type": "string",
-            "description": "This is a duration:"
+            "description": "This is a duration:",
+            "format": "regex"
         }
     },
     "additionalProperties": true,

--- a/internal/converter/testdata/wellknown.go
+++ b/internal/converter/testdata/wellknown.go
@@ -28,7 +28,7 @@ const WellKnown = `{
             "type": "array"
         },
         "duration": {
-            "pattern": "^([0-9]+\\.?[0-9]*|\\.[0-9]+)(ns|ms|s|m|h|d)$",
+            "pattern": "^([0-9]+\\.?[0-9]*|\\.[0-9]+)s$",
             "type": "string",
             "description": "This is a duration:",
             "format": "regex"

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -181,6 +181,10 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 
 	case descriptor.FieldDescriptorProto_TYPE_GROUP, descriptor.FieldDescriptorProto_TYPE_MESSAGE:
 		switch desc.GetTypeName() {
+		case ".google.protobuf.Duration":
+			jsonSchemaType.Type = gojsonschema.TYPE_STRING
+			jsonSchemaType.Format = "regex"
+			jsonSchemaType.Pattern = `^([0-9]+\.?[0-9]*|\.[0-9]+)(ns|ms|s|m|h|d)$`
 		case ".google.protobuf.Timestamp":
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
 			jsonSchemaType.Format = "date-time"

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -181,10 +181,11 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 
 	case descriptor.FieldDescriptorProto_TYPE_GROUP, descriptor.FieldDescriptorProto_TYPE_MESSAGE:
 		switch desc.GetTypeName() {
+		// Make sure that durations match a particular string pattern (eg 3.4s):
 		case ".google.protobuf.Duration":
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
 			jsonSchemaType.Format = "regex"
-			jsonSchemaType.Pattern = `^([0-9]+\.?[0-9]*|\.[0-9]+)(ns|ms|s|m|h|d)$`
+			jsonSchemaType.Pattern = `^([0-9]+\.?[0-9]*|\.[0-9]+)s$`
 		case ".google.protobuf.Timestamp":
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
 			jsonSchemaType.Format = "date-time"


### PR DESCRIPTION
This sets a custom format for google.protobuf.Duration:
- format: `regex`
- pattern: `^([0-9]+\.?[0-9]*|\.[0-9]+)(ns|ms|s|m|h|d)$`

This regex matches any number (with an optional decimal), as long as it ends in one of the specified suffixes:
- `ns`
- `ms`
- `s`
- `m`
- `h`
- `d`