### PR TITLE
Comments for google types

### DIFF
--- a/internal/converter/testdata/google_value.go
+++ b/internal/converter/testdata/google_value.go
@@ -20,7 +20,8 @@ const GoogleValue = `{
                 {
                     "type": "string"
                 }
-            ]
+            ],
+            "description": "` + "`Value`" + ` represents a dynamically typed value which can be either\n null, a number, a string, a boolean, a recursive struct value, or a\n list of values. A producer of value is expected to set one of that\n variants, absence of any variant indicates an error.\n\n The JSON representation for ` + "`Value`" + ` is JSON value."
         }
     },
     "additionalProperties": true,

--- a/internal/converter/testdata/proto/WellKnown.proto
+++ b/internal/converter/testdata/proto/WellKnown.proto
@@ -8,6 +8,7 @@ message WellKnown {
     map<int32, google.protobuf.Int32Value> map_of_integers = 2;
     map<int32, int32> map_of_scalar_integers = 3;
     repeated google.protobuf.Int32Value list_of_integers = 4;
+    // This is a duration:
     google.protobuf.Duration duration = 5;
 }
 

--- a/internal/converter/testdata/wellknown.go
+++ b/internal/converter/testdata/wellknown.go
@@ -22,13 +22,15 @@ const WellKnown = `{
         },
         "list_of_integers": {
             "items": {
-                "type": "integer"
+                "type": "integer",
+                "description": "Wrapper message for ` + "`int32`" + `.\n\n The JSON representation for ` + "`Int32Value`" + ` is JSON number."
             },
             "type": "array"
         },
         "duration": {
             "additionalProperties": true,
-            "type": "string"
+            "type": "string",
+            "description": "This is a duration:"
         }
     },
     "additionalProperties": true,


### PR DESCRIPTION
This PR allows the google well-known types to have comments added to the description field. It turns out that this logic was being bypassed for wellknown types.