### PR TITLE
Disallow additional fields on inner objects

### DIFF
--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -197,6 +197,9 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			if desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_REQUIRED {
 				jsonSchemaType.AdditionalProperties = []byte("false")
 			}
+			if c.Flags.DisallowAdditionalProperties {
+				jsonSchemaType.AdditionalProperties = []byte("false")
+			}
 		}
 
 	default:


### PR DESCRIPTION
When using the `disallow_additional_properties` field, inline-defined child objects still get `"additionalProperties": true` set.