### PR TITLE
Custom $ref prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ protoc \ # The protobuf compiler
 |`json_fieldnames`| Use JSON field names only |
 |`prefix_schema_files_with_package`| Prefix the output filename with package |
 |`proto_and_json_fieldnames`| Use proto and JSON field names |
+|`ref_prefix`| Provide a custom prefix for referenced schemas |
 
 ## Examples
 

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -22,12 +22,11 @@ const (
 
 // Converter is everything you need to convert protos to JSONSchemas:
 type Converter struct {
-	Flags               ConverterFlags
-	ignoredFieldOption  string
-	logger              *logrus.Logger
-	requiredFieldOption string
-	sourceInfo          *sourceCodeInfo
-	messageTargets      []string
+	Flags          ConverterFlags
+	logger         *logrus.Logger
+	messageTargets []string
+	refPrefix      string
+	sourceInfo     *sourceCodeInfo
 }
 
 // ConverterFlags control the behaviour of the converter:
@@ -91,8 +90,7 @@ func (c *Converter) parseGeneratorParameters(parameters string) {
 		case "proto_and_json_fieldnames":
 			c.Flags.UseProtoAndJSONFieldNames = true
 		}
-
-		// look for specific message targets
+		// look for specific message targets:
 		// message types are separated by messageDelimiter "+"
 		// examples:
 		// 		messages=[foo+bar]
@@ -100,6 +98,14 @@ func (c *Converter) parseGeneratorParameters(parameters string) {
 		rx := regexp.MustCompile(`messages=\[([^\]]+)\]`)
 		if matches := rx.FindStringSubmatch(parameter); len(matches) == 2 {
 			c.messageTargets = strings.Split(matches[1], messageDelimiter)
+		}
+
+		// Look for a custom $ref prefix ($references will be prefixed with this string):
+		if strings.Contains(parameter, "ref_prefix=") {
+			refPrefixSetting := strings.Split(parameter, "=")
+			if len(refPrefixSetting) == 2 {
+				c.refPrefix = refPrefixSetting[1]
+			}
 		}
 	}
 }

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -26,6 +26,7 @@ type sampleProto struct {
 	ExpectedJSONSchema []string
 	FilesToGenerate    []string
 	ProtoFileName      string
+	RefPrefix          string
 	TargetedMessages   []string
 }
 
@@ -53,6 +54,7 @@ func testConvertSampleProto(t *testing.T, sampleProto sampleProto) {
 	// Use the logger to make a Converter:
 	protoConverter := New(logger)
 	protoConverter.Flags = sampleProto.Flags
+	protoConverter.refPrefix = sampleProto.RefPrefix
 
 	// Open the sample proto file:
 	sampleProtoFileName := fmt.Sprintf("%v/%v", sampleProtoDirectory, sampleProto.ProtoFileName)
@@ -277,6 +279,12 @@ func configureSampleProtos() map[string]sampleProto {
 			ExpectedJSONSchema: []string{testdata.FieldOptions, testdata.Proto3Required},
 			FilesToGenerate:    []string{"options.proto", "Proto3Required.proto"},
 			ProtoFileName:      "Proto3Required.proto",
+		},
+		"RefPrefix": {
+			ExpectedJSONSchema: []string{testdata.RefPrefixM, testdata.RefPrefixFoo, testdata.RefPrefixBar, testdata.RefPrefixBaz},
+			FilesToGenerate:    []string{"CyclicalReference.proto"},
+			ProtoFileName:      "CyclicalReference.proto",
+			RefPrefix:          "#/definitions/",
 		},
 	}
 }

--- a/internal/converter/testdata/ref_prefix.go
+++ b/internal/converter/testdata/ref_prefix.go
@@ -1,0 +1,183 @@
+package testdata
+
+const RefPrefixM = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "foo": {
+            "$ref": "#/definitions/samples.Foo",
+            "additionalProperties": true
+        }
+    },
+    "additionalProperties": true,
+    "type": "object",
+    "definitions": {
+        "samples.Foo": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "bar": {
+                    "items": {
+                        "$schema": "http://json-schema.org/draft-04/schema#",
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "baz": {
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "foo": {
+                                        "$ref": "#/definitions/samples.Foo",
+                                        "additionalProperties": true
+                                    }
+                                },
+                                "additionalProperties": true,
+                                "type": "object"
+                            }
+                        },
+                        "additionalProperties": true,
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "id": "samples.Foo"
+        }
+    }
+}`
+
+const RefPrefixFoo = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/Foo",
+    "definitions": {
+        "Foo": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "bar": {
+                    "items": {
+                        "$schema": "http://json-schema.org/draft-04/schema#",
+                        "properties": {
+                            "id": {
+                                "type": "integer"
+                            },
+                            "baz": {
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "foo": {
+                                        "$ref": "#/definitions/Foo",
+                                        "additionalProperties": true
+                                    }
+                                },
+                                "additionalProperties": true,
+                                "type": "object"
+                            }
+                        },
+                        "additionalProperties": true,
+                        "type": "object"
+                    },
+                    "type": "array"
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "id": "Foo"
+        }
+    }
+}`
+
+const RefPrefixBar = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/Bar",
+    "definitions": {
+        "Bar": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "id": {
+                    "type": "integer"
+                },
+                "baz": {
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "foo": {
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "bar": {
+                                    "items": {
+                                        "$schema": "http://json-schema.org/draft-04/schema#",
+                                        "$ref": "#/definitions/Bar"
+                                    },
+                                    "type": "array"
+                                }
+                            },
+                            "additionalProperties": true,
+                            "type": "object"
+                        }
+                    },
+                    "additionalProperties": true,
+                    "type": "object"
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "id": "Bar"
+        }
+    }
+}`
+
+const RefPrefixBaz = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/Baz",
+    "definitions": {
+        "Baz": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "foo": {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "bar": {
+                            "items": {
+                                "$schema": "http://json-schema.org/draft-04/schema#",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer"
+                                    },
+                                    "baz": {
+                                        "$ref": "#/definitions/Baz",
+                                        "additionalProperties": true
+                                    }
+                                },
+                                "additionalProperties": true,
+                                "type": "object"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "additionalProperties": true,
+                    "type": "object"
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "id": "Baz"
+        }
+    }
+}`

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -474,7 +474,7 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msg *descr
 	if refName, ok := duplicatedMessages[msg]; ok && !ignoreDuplicatedMessages {
 		return &jsonschema.Type{
 			Version: jsonschema.Version,
-			Ref:     refName,
+			Ref:     fmt.Sprintf("%s%s", c.refPrefix, refName),
 		}, nil
 	}
 


### PR DESCRIPTION
This PR introduces a new feature which allows the user to define a custom prefix for $ref links used within the generated schemas.