### PR TITLE
Rendering google.protobuf.Struct as an OBJECT

### DIFF
--- a/internal/converter/testdata/proto/WellKnown.proto
+++ b/internal/converter/testdata/proto/WellKnown.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package samples;
 import "google/protobuf/duration.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
 message WellKnown {
@@ -10,5 +11,6 @@ message WellKnown {
     repeated google.protobuf.Int32Value list_of_integers = 4;
     // This is a duration:
     google.protobuf.Duration duration = 5;
+    google.protobuf.Struct struct = 6;
 }
 

--- a/internal/converter/testdata/wellknown.go
+++ b/internal/converter/testdata/wellknown.go
@@ -35,6 +35,10 @@ const WellKnown = `{
                     "type": "string",
                     "description": "This is a duration:",
                     "format": "regex"
+                },
+                "struct": {
+                    "additionalProperties": true,
+                    "type": "object"
                 }
             },
             "additionalProperties": true,

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -28,6 +28,7 @@ var (
 		"BytesValue":  true,
 		"Value":       true,
 		"Duration":    true,
+		"Struct":      true,
 	}
 )
 
@@ -439,6 +440,8 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msg *descr
 			}
 		case "Duration":
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
+		case "Struct":
+			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
 		}
 
 		// If we're allowing nulls then prepare a OneOf:


### PR DESCRIPTION
Adding a special case for google.protobuf.Struct. We already had the code in place for this, so its a simple change. See the unit-test modifications for the details of what the schema looks like.