### PR TITLE
Use JSON field names in required list when json_fieldnames is used

### DIFF
--- a/internal/converter/testdata/json_fields.go
+++ b/internal/converter/testdata/json_fields.go
@@ -5,6 +5,9 @@ const JSONFields = `{
     "$ref": "#/definitions/JSONFields",
     "definitions": {
         "JSONFields": {
+            "required": [
+                "otherNumb"
+            ],
             "properties": {
                 "name": {
                     "type": "string"
@@ -23,6 +26,9 @@ const JSONFields = `{
                 },
                 "snakeNumb": {
                     "type": "string"
+                },
+                "otherNumb": {
+                    "type": "integer"
                 }
             },
             "additionalProperties": true,
@@ -31,6 +37,6 @@ const JSONFields = `{
     }
 }`
 
-const JSONFieldsFail = `{"someThing": "onetwothree"}`
+const JSONFieldsFail = `{"someThing": "onetwothree", "other_numb": 123}`
 
-const JSONFieldsPass = `{"someThing": 12345}`
+const JSONFieldsPass = `{"someThing": 12345, "otherNumb": 123}`

--- a/internal/converter/testdata/proto/JSONFields.proto
+++ b/internal/converter/testdata/proto/JSONFields.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 package samples;
+import "options.proto";
 
 message JSONFields {
     string name      = 1;
@@ -8,4 +9,5 @@ message JSONFields {
     float some_thing = 4 [json_name="someThing"];
     bool complete    = 5;
     int64 snake_numb = 6;
+    int32 other_numb = 7 [(protoc.gen.jsonschema.field_options).required = true];
 }

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -525,7 +525,11 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msgDesc *d
 					// "Required" fields are added to the list of required attributes in our schema:
 					if fieldOptions.GetRequired() {
 						c.logger.WithField("field_name", fieldDesc.GetName()).WithField("message_name", msgDesc.GetName()).Debug("Marking required field")
-						jsonSchemaType.Required = append(jsonSchemaType.Required, fieldDesc.GetName())
+						if c.Flags.UseJSONFieldnamesOnly {
+							jsonSchemaType.Required = append(jsonSchemaType.Required, fieldDesc.GetJsonName())
+						} else {
+							jsonSchemaType.Required = append(jsonSchemaType.Required, fieldDesc.GetName())
+						}
 					}
 				}
 			}
@@ -564,7 +568,11 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msgDesc *d
 
 		// Look for required fields by the proto2 "required" flag:
 		if fieldDesc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_REQUIRED && fieldDesc.OneofIndex == nil {
-			jsonSchemaType.Required = append(jsonSchemaType.Required, fieldDesc.GetName())
+			if c.Flags.UseJSONFieldnamesOnly {
+				jsonSchemaType.Required = append(jsonSchemaType.Required, fieldDesc.GetJsonName())
+			} else {
+				jsonSchemaType.Required = append(jsonSchemaType.Required, fieldDesc.GetName())
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, the required fields list will always contain only the protobuf names
of fields, even if the json_fieldnames option is used.

In this commit, the behavior is changed to instead use JSON names if the
json_fieldnames option is used and proto names in all the other cases.