### PR TITLE
Add a flag to only generate strings in enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The following configuration parameters are supported. They should be added to th
 |`disallow_additional_properties`| Disallow additional properties in schema |
 |`disallow_bigints_as_strings`| Disallow big integers as strings |
 |`enforce_oneof`| Interpret Proto "oneOf" clauses |
+|`enum_as_strings_only`| Only include strings in the allowed values for enums |
 |`file_extension`| Specify a custom file extension for generated schemas |
 |`json_fieldnames`| Use JSON field names only |
 |`prefix_schema_files_with_package`| Prefix the output filename with package |

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -286,6 +286,16 @@ func configureSampleProtos() map[string]sampleProto {
 			ObjectsToValidateFail: []string{testdata.OptionEnumsAsConstantsFail},
 			ObjectsToValidatePass: []string{testdata.OptionEnumsAsConstantsPass},
 		},
+		"OptionEnumsAsStringsOnly": {
+			Flags: ConverterFlags{
+				EnumsAsStringsOnly: true,
+			},
+			ExpectedJSONSchema:    []string{testdata.OptionEnumsAsStringsOnly},
+			FilesToGenerate:       []string{"OptionEnumsAsStringsOnly.proto"},
+			ProtoFileName:         "OptionEnumsAsStringsOnly.proto",
+			ObjectsToValidateFail: []string{testdata.OptionEnumsAsStringsOnlyFail},
+			ObjectsToValidatePass: []string{testdata.OptionEnumsAsStringsOnlyPass},
+		},
 		"OptionFileExtension": {
 			ExpectedJSONSchema: []string{testdata.OptionFileExtension},
 			ExpectedFileNames:  []string{"OptionFileExtension.jsonschema"},

--- a/internal/converter/testdata/option_enums_as_strings_only.go
+++ b/internal/converter/testdata/option_enums_as_strings_only.go
@@ -1,0 +1,15 @@
+package testdata
+
+const OptionEnumsAsStringsOnly = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "enum": [
+        "NOT_SPECIFIED",
+        "USD",
+        "GBP",
+        "EUR"
+    ],
+    "type": "string"
+}`
+
+const OptionEnumsAsStringsOnlyPass = `"NOT_SPECIFIED"`
+const OptionEnumsAsStringsOnlyFail = `2`

--- a/internal/converter/testdata/proto/OptionEnumsAsStringsOnly.proto
+++ b/internal/converter/testdata/proto/OptionEnumsAsStringsOnly.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+package samples;
+
+enum Currency {
+    NOT_SPECIFIED = 0;
+    USD = 1;
+    GBP = 2;
+    EUR = 3;
+}


### PR DESCRIPTION
This is useful for forms that are automatically generated from a schema. Instead of including both enum value names and numbers in the selection list, or implementing a hack to merge numbers with names, we could generate a schema that only has the names.