### PR TITLE
Using detached-leading-comments as title field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.14
 
 require (
 	github.com/alecthomas/jsonschema v0.0.0-20210918223802-a1d3f4b43d7b
+	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/iancoleman/orderedmap v0.2.0
+	github.com/iancoleman/strcase v0.2.0 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -3,12 +3,16 @@ github.com/alecthomas/jsonschema v0.0.0-20210918223802-a1d3f4b43d7b/go.mod h1:/n
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8=
+github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/iancoleman/orderedmap v0.2.0 h1:sq1N/TFpYH++aViPcaKjys3bDClUEU7s5B+z6jq8pNA=
 github.com/iancoleman/orderedmap v0.2.0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -155,7 +155,7 @@ func (c *Converter) convertEnumType(enum *descriptor.EnumDescriptorProto, conver
 
 	// Generate a description from src comments (if available):
 	if src := c.sourceInfo.GetEnum(enum); src != nil {
-		jsonSchemaType.Description = formatDescription(src)
+		jsonSchemaType.Title, jsonSchemaType.Description = formatTitleAndDescription(src)
 	}
 
 	// Use basic types if we're not opting to use constants for ENUMs:
@@ -183,7 +183,7 @@ func (c *Converter) convertEnumType(enum *descriptor.EnumDescriptorProto, conver
 		// Each ENUM value can have comments too:
 		var valueDescription string
 		if src := c.sourceInfo.GetEnumValue(value); src != nil {
-			valueDescription = formatDescription(src)
+			_, valueDescription = formatTitleAndDescription(src)
 		}
 
 		// If we're using constants for ENUMs then add these here, along with their title:

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -158,7 +158,7 @@ func (c *Converter) convertEnumType(enum *descriptor.EnumDescriptorProto, conver
 
 	// Generate a description from src comments (if available):
 	if src := c.sourceInfo.GetEnum(enum); src != nil {
-		jsonSchemaType.Title, jsonSchemaType.Description = c.formatTitleAndDescription(src)
+		jsonSchemaType.Title, jsonSchemaType.Description = c.formatTitleAndDescription(strPtr(enum.GetName()), src)
 	}
 
 	// Use basic types if we're not opting to use constants for ENUMs:
@@ -186,7 +186,7 @@ func (c *Converter) convertEnumType(enum *descriptor.EnumDescriptorProto, conver
 		// Each ENUM value can have comments too:
 		var valueDescription string
 		if src := c.sourceInfo.GetEnumValue(value); src != nil {
-			_, valueDescription = c.formatTitleAndDescription(src)
+			_, valueDescription = c.formatTitleAndDescription(nil, src)
 		}
 
 		// If we're using constants for ENUMs then add these here, along with their title:

--- a/internal/converter/sourcecodeinfo.go
+++ b/internal/converter/sourcecodeinfo.go
@@ -118,7 +118,7 @@ func getDefinitionAtPath(file *descriptor.FileDescriptorProto, path []int32) pro
 }
 
 // formatTitleAndDescription returns a title string and a description string, made from proto comments:
-func formatTitleAndDescription(sl *descriptor.SourceCodeInfo_Location) (title, description string) {
+func (c *Converter) formatTitleAndDescription(sl *descriptor.SourceCodeInfo_Location) (title, description string) {
 	var comments []string
 	for _, str := range sl.GetLeadingDetachedComments() {
 		if s := strings.TrimSpace(str); s != "" {
@@ -138,7 +138,7 @@ func formatTitleAndDescription(sl *descriptor.SourceCodeInfo_Location) (title, d
 	}
 
 	// The description is all the comments joined together:
-	description = strings.Join(comments, "\n\n")
+	description = strings.Join(comments, c.commentDelimiter)
 
 	return
 }

--- a/internal/converter/sourcecodeinfo.go
+++ b/internal/converter/sourcecodeinfo.go
@@ -1,6 +1,8 @@
 package converter
 
 import (
+	"strings"
+
 	"google.golang.org/protobuf/proto"
 	descriptor "google.golang.org/protobuf/types/descriptorpb"
 )
@@ -113,4 +115,30 @@ func getDefinitionAtPath(file *descriptor.FileDescriptorProto, path []int32) pro
 		}
 	}
 	return pos
+}
+
+// formatTitleAndDescription returns a title string and a description string, made from proto comments:
+func formatTitleAndDescription(sl *descriptor.SourceCodeInfo_Location) (title, description string) {
+	var comments []string
+	for _, str := range sl.GetLeadingDetachedComments() {
+		if s := strings.TrimSpace(str); s != "" {
+			comments = append(comments, s)
+		}
+	}
+	if s := strings.TrimSpace(sl.GetLeadingComments()); s != "" {
+		comments = append(comments, s)
+	}
+	if s := strings.TrimSpace(sl.GetTrailingComments()); s != "" {
+		comments = append(comments, s)
+	}
+
+	// The title becomes the first comment (if one exists):
+	if len(comments) > 1 {
+		title = comments[0]
+	}
+
+	// The description is all the comments joined together:
+	description = strings.Join(comments, "\n\n")
+
+	return
 }

--- a/internal/converter/sourcecodeinfo_test.go
+++ b/internal/converter/sourcecodeinfo_test.go
@@ -47,8 +47,3 @@ func assertCommentsMatch(t *testing.T, actual, expected *descriptor.SourceCodeIn
 			actual.GetLeadingComments(), expected.GetLeadingComments())
 	}
 }
-
-// Go doesn't have syntax for addressing a string literal, so this is the next best thing.
-func strPtr(s string) *string {
-	return &s
-}

--- a/internal/converter/sourcecodeinfo_test.go
+++ b/internal/converter/sourcecodeinfo_test.go
@@ -20,7 +20,7 @@ func TestSourceInfoLookup(t *testing.T) {
 	src := newSourceCodeInfo(fds.File)
 	assertCommentsMatch(t, src.GetMessage(msgWithComments), &descriptor.SourceCodeInfo_Location{
 		LeadingComments:         strPtr(" This is a message level comment and talks about what this message is and why you should care about it!\n"),
-		LeadingDetachedComments: []string{" This is a detached leading comment (which becomes the title)\n"},
+		LeadingDetachedComments: []string{" This is a leading detached comment (which becomes the title)\n"},
 	})
 	assertCommentsMatch(t, src.GetField(msgWithComments_name1), &descriptor.SourceCodeInfo_Location{
 		LeadingComments: strPtr(" This field is supposed to represent blahblahblah\n"),

--- a/internal/converter/sourcecodeinfo_test.go
+++ b/internal/converter/sourcecodeinfo_test.go
@@ -19,7 +19,8 @@ func TestSourceInfoLookup(t *testing.T) {
 	// source data for each of our above declarations.
 	src := newSourceCodeInfo(fds.File)
 	assertCommentsMatch(t, src.GetMessage(msgWithComments), &descriptor.SourceCodeInfo_Location{
-		LeadingComments: strPtr(" This is a message level comment and talks about what this message is and why you should care about it!\n"),
+		LeadingComments:         strPtr(" This is a message level comment and talks about what this message is and why you should care about it!\n"),
+		LeadingDetachedComments: []string{" This is a detached leading comment (which becomes the title)\n"},
 	})
 	assertCommentsMatch(t, src.GetField(msgWithComments_name1), &descriptor.SourceCodeInfo_Location{
 		LeadingComments: strPtr(" This field is supposed to represent blahblahblah\n"),

--- a/internal/converter/testdata/array_of_enums.go
+++ b/internal/converter/testdata/array_of_enums.go
@@ -22,11 +22,13 @@ const ArrayOfEnums = `{
                             3
                         ]
                     },
-                    "type": "array"
+                    "type": "array",
+                    "title": "Inline"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Array Of Enums"
         }
     }
 }`

--- a/internal/converter/testdata/array_of_messages.go
+++ b/internal/converter/testdata/array_of_messages.go
@@ -17,7 +17,8 @@ const ArrayOfMessages = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Array Of Messages"
         },
         "samples.PayloadMessage": {
             "properties": {
@@ -58,11 +59,13 @@ const ArrayOfMessages = `{
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Payload Message"
         }
     }
 }`

--- a/internal/converter/testdata/array_of_objects.go
+++ b/internal/converter/testdata/array_of_objects.go
@@ -38,7 +38,8 @@ const ArrayOfObjects = `{
                 {
                     "type": "object"
                 }
-            ]
+            ],
+            "title": "Array Of Objects"
         },
         "samples.ArrayOfObjects.RepeatedPayload": {
             "properties": {
@@ -117,7 +118,8 @@ const ArrayOfObjects = `{
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
@@ -128,7 +130,8 @@ const ArrayOfObjects = `{
                 {
                     "type": "object"
                 }
-            ]
+            ],
+            "title": "Repeated Payload"
         }
     }
 }`

--- a/internal/converter/testdata/array_of_primitives.go
+++ b/internal/converter/testdata/array_of_primitives.go
@@ -95,7 +95,8 @@ const ArrayOfPrimitives = `{
                 {
                     "type": "object"
                 }
-            ]
+            ],
+            "title": "Array Of Primitives"
         }
     }
 }`
@@ -209,7 +210,8 @@ const ArrayOfPrimitivesDouble = `{
                 {
                     "type": "object"
                 }
-            ]
+            ],
+            "title": "Array Of Primitives"
         }
     }
 }`

--- a/internal/converter/testdata/bytes_payload.go
+++ b/internal/converter/testdata/bytes_payload.go
@@ -16,7 +16,8 @@ const BytesPayload = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Bytes Payload"
         }
     }
 }`

--- a/internal/converter/testdata/cyclical_reference.go
+++ b/internal/converter/testdata/cyclical_reference.go
@@ -12,7 +12,8 @@ const CyclicalReferenceMessageM = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "M"
         },
         "samples.Bar": {
             "properties": {
@@ -25,7 +26,8 @@ const CyclicalReferenceMessageM = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Bar"
         },
         "samples.Baz": {
             "properties": {
@@ -38,7 +40,8 @@ const CyclicalReferenceMessageM = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Baz"
         },
         "samples.Foo": {
             "properties": {
@@ -53,7 +56,8 @@ const CyclicalReferenceMessageM = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Foo"
         }
     }
 }`
@@ -75,7 +79,8 @@ const CyclicalReferenceMessageFoo = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Foo"
         },
         "samples.Bar": {
             "properties": {
@@ -88,7 +93,8 @@ const CyclicalReferenceMessageFoo = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Bar"
         },
         "samples.Baz": {
             "properties": {
@@ -101,7 +107,8 @@ const CyclicalReferenceMessageFoo = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Baz"
         }
     }
 }`
@@ -121,7 +128,8 @@ const CyclicalReferenceMessageBar = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Bar"
         },
         "samples.Baz": {
             "properties": {
@@ -134,7 +142,8 @@ const CyclicalReferenceMessageBar = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Baz"
         },
         "samples.Foo": {
             "properties": {
@@ -149,7 +158,8 @@ const CyclicalReferenceMessageBar = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Foo"
         }
     }
 }`
@@ -169,7 +179,8 @@ const CyclicalReferenceMessageBaz = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Baz"
         },
         "samples.Bar": {
             "properties": {
@@ -182,7 +193,8 @@ const CyclicalReferenceMessageBaz = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Bar"
         },
         "samples.Foo": {
             "properties": {
@@ -197,7 +209,8 @@ const CyclicalReferenceMessageBaz = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Foo"
         }
     }
 }`

--- a/internal/converter/testdata/enum_ception.go
+++ b/internal/converter/testdata/enum_ception.go
@@ -36,6 +36,7 @@ const EnumCeption = `{
                             "type": "integer"
                         }
                     ],
+                    "title": "Failure Modes",
                     "description": "FailureModes enum"
                 },
                 "payload": {
@@ -93,11 +94,13 @@ const EnumCeption = `{
                             "const": 3
                         }
                     ],
+                    "title": "Imported Enum",
                     "description": "This is an enum"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Enumception"
         },
         "samples.PayloadMessage": {
             "properties": {
@@ -138,11 +141,13 @@ const EnumCeption = `{
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Payload Message"
         }
     }
 }`

--- a/internal/converter/testdata/enum_nested_reference.go
+++ b/internal/converter/testdata/enum_nested_reference.go
@@ -28,11 +28,13 @@ const EnumNestedReference = `{
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Msg"
         }
     }
 }`

--- a/internal/converter/testdata/enum_with_message.go
+++ b/internal/converter/testdata/enum_with_message.go
@@ -22,11 +22,13 @@ const EnumWithMessage = `{
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Foo Bar Baz"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "With Foo Bar Baz"
         }
     }
 }`

--- a/internal/converter/testdata/first_enum.go
+++ b/internal/converter/testdata/first_enum.go
@@ -19,7 +19,8 @@ const FirstEnum = `{
         {
             "type": "integer"
         }
-    ]
+    ],
+    "title": "First Enum"
 }`
 
 const FirstEnumFail = `5`

--- a/internal/converter/testdata/first_message.go
+++ b/internal/converter/testdata/first_message.go
@@ -23,7 +23,8 @@ const FirstMessage = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "First Message"
         }
     }
 }`

--- a/internal/converter/testdata/google_value.go
+++ b/internal/converter/testdata/google_value.go
@@ -24,11 +24,13 @@ const GoogleValue = `{
                             "type": "string"
                         }
                     ],
+                    "title": "Value",
                     "description": "` + "`Value`" + ` represents a dynamically typed value which can be either\n null, a number, a string, a boolean, a recursive struct value, or a\n list of values. A producer of value is expected to set one of these\n variants. Absence of any variant indicates an error.\n\n The JSON representation for ` + "`Value`" + ` is JSON value."
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Google Value"
         }
     }
 }`

--- a/internal/converter/testdata/imported_enum.go
+++ b/internal/converter/testdata/imported_enum.go
@@ -46,6 +46,7 @@ const ImportedEnum = `{
             "const": 3
         }
     ],
+    "title": "Imported Enum",
     "description": "This is an enum"
 }`
 

--- a/internal/converter/testdata/json_fields.go
+++ b/internal/converter/testdata/json_fields.go
@@ -32,7 +32,8 @@ const JSONFields = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "JSON Fields"
         }
     }
 }`

--- a/internal/converter/testdata/maps.go
+++ b/internal/converter/testdata/maps.go
@@ -27,7 +27,8 @@ const Maps = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Maps"
         },
         "samples.PayloadMessage": {
             "properties": {
@@ -68,11 +69,13 @@ const Maps = `{
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Payload Message"
         }
     }
 }`

--- a/internal/converter/testdata/message_kind_10.go
+++ b/internal/converter/testdata/message_kind_10.go
@@ -23,7 +23,8 @@ const MessageKind10 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 10"
         }
     }
 }`

--- a/internal/converter/testdata/message_kind_11.go
+++ b/internal/converter/testdata/message_kind_11.go
@@ -29,7 +29,8 @@ const MessageKind11 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 11"
         },
         "samples.MessageKind1": {
             "properties": {
@@ -50,7 +51,8 @@ const MessageKind11 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 1"
         },
         "samples.MessageKind2": {
             "properties": {
@@ -77,7 +79,8 @@ const MessageKind11 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 2"
         },
         "samples.MessageKind3": {
             "properties": {
@@ -101,7 +104,8 @@ const MessageKind11 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 3"
         },
         "samples.MessageKind4": {
             "properties": {
@@ -125,7 +129,8 @@ const MessageKind11 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 4"
         }
     }
 }`

--- a/internal/converter/testdata/message_kind_12.go
+++ b/internal/converter/testdata/message_kind_12.go
@@ -27,7 +27,8 @@ const MessageKind12 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 12"
         },
         "samples.MessageKind1": {
             "properties": {
@@ -48,7 +49,8 @@ const MessageKind12 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 1"
         },
         "samples.MessageKind11": {
             "properties": {
@@ -75,7 +77,8 @@ const MessageKind12 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 11"
         },
         "samples.MessageKind2": {
             "properties": {
@@ -102,7 +105,8 @@ const MessageKind12 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 2"
         },
         "samples.MessageKind3": {
             "properties": {
@@ -126,7 +130,8 @@ const MessageKind12 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 3"
         },
         "samples.MessageKind4": {
             "properties": {
@@ -150,7 +155,8 @@ const MessageKind12 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 4"
         },
         "samples.MessageKind5": {
             "properties": {
@@ -174,7 +180,8 @@ const MessageKind12 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 5"
         },
         "samples.MessageKind6": {
             "properties": {
@@ -198,7 +205,8 @@ const MessageKind12 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 6"
         },
         "samples.MessageKind7": {
             "properties": {
@@ -222,7 +230,8 @@ const MessageKind12 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 7"
         }
     }
 }`

--- a/internal/converter/testdata/message_with_comments.go
+++ b/internal/converter/testdata/message_with_comments.go
@@ -13,8 +13,8 @@ const MessageWithComments = `{
             },
             "additionalProperties": true,
             "type": "object",
-            "title": "This is a detached leading comment (which becomes the title)",
-            "description": "This is a detached leading comment (which becomes the title)\n\nThis is a message level comment and talks about what this message is and why you should care about it!"
+            "title": "This is a leading detached comment (which becomes the title)",
+            "description": "This is a leading detached comment (which becomes the title)\n\nThis is a message level comment and talks about what this message is and why you should care about it!"
         }
     }
 }`

--- a/internal/converter/testdata/message_with_comments.go
+++ b/internal/converter/testdata/message_with_comments.go
@@ -13,7 +13,8 @@ const MessageWithComments = `{
             },
             "additionalProperties": true,
             "type": "object",
-            "description": "This is a message level comment and talks about what this message is and why you should care about it!"
+            "title": "This is a detached leading comment (which becomes the title)",
+            "description": "This is a detached leading comment (which becomes the title)\n\nThis is a message level comment and talks about what this message is and why you should care about it!"
         }
     }
 }`

--- a/internal/converter/testdata/message_with_comments.go
+++ b/internal/converter/testdata/message_with_comments.go
@@ -14,7 +14,7 @@ const MessageWithComments = `{
             "additionalProperties": true,
             "type": "object",
             "title": "This is a leading detached comment (which becomes the title)",
-            "description": "This is a leading detached comment (which becomes the title)\n\nThis is a message level comment and talks about what this message is and why you should care about it!"
+            "description": "This is a leading detached comment (which becomes the title)  This is a message level comment and talks about what this message is and why you should care about it!"
         }
     }
 }`

--- a/internal/converter/testdata/nested_message.go
+++ b/internal/converter/testdata/nested_message.go
@@ -15,7 +15,8 @@ const NestedMessage = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Nested Message"
         },
         "samples.PayloadMessage": {
             "properties": {
@@ -56,11 +57,13 @@ const NestedMessage = `{
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Payload Message"
         }
     }
 }`

--- a/internal/converter/testdata/nested_object.go
+++ b/internal/converter/testdata/nested_object.go
@@ -15,7 +15,8 @@ const NestedObject = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Nested Object"
         },
         "samples.NestedObject.NestedPayload": {
             "properties": {
@@ -56,11 +57,13 @@ const NestedObject = `{
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Nested Payload"
         }
     }
 }`

--- a/internal/converter/testdata/oneof.go
+++ b/internal/converter/testdata/oneof.go
@@ -31,7 +31,8 @@ const OneOf = `{
                         "baz"
                     ]
                 }
-            ]
+            ],
+            "title": "One Of"
         },
         "samples.OneOf.Bar": {
             "required": [
@@ -43,7 +44,8 @@ const OneOf = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Bar"
         },
         "samples.OneOf.Baz": {
             "required": [
@@ -55,7 +57,8 @@ const OneOf = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Baz"
         }
     }
 }`

--- a/internal/converter/testdata/option_allow_null_values.go
+++ b/internal/converter/testdata/option_allow_null_values.go
@@ -45,7 +45,8 @@ const OptionAllowNullValues = `{
                 {
                     "type": "object"
                 }
-            ]
+            ],
+            "title": "Option Allow Null Values"
         }
     }
 }`

--- a/internal/converter/testdata/option_disallow_additional_properties.go
+++ b/internal/converter/testdata/option_disallow_additional_properties.go
@@ -23,7 +23,8 @@ const OptionDisallowAdditionalProperties = `{
                 }
             },
             "additionalProperties": false,
-            "type": "object"
+            "type": "object",
+            "title": "Option Disallow Additional Properties"
         }
     }
 }`

--- a/internal/converter/testdata/option_enums_as_constants.go
+++ b/internal/converter/testdata/option_enums_as_constants.go
@@ -51,11 +51,13 @@ const OptionEnumsAsConstants = `{
                             "const": 3
                         }
                     ],
+                    "title": "Imported Enum",
                     "description": "This is an enum"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Option Enums As Constants"
         }
     }
 }`

--- a/internal/converter/testdata/option_enums_as_strings_only.go
+++ b/internal/converter/testdata/option_enums_as_strings_only.go
@@ -8,7 +8,8 @@ const OptionEnumsAsStringsOnly = `{
         "GBP",
         "EUR"
     ],
-    "type": "string"
+    "type": "string",
+    "title": "Currency"
 }`
 
 const OptionEnumsAsStringsOnlyPass = `"NOT_SPECIFIED"`

--- a/internal/converter/testdata/option_file_extension.go
+++ b/internal/converter/testdata/option_file_extension.go
@@ -23,7 +23,8 @@ const OptionFileExtension = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Option File Extension"
         }
     }
 }`

--- a/internal/converter/testdata/option_ignored_field.go
+++ b/internal/converter/testdata/option_ignored_field.go
@@ -14,7 +14,8 @@ const OptionIgnoredField = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Option Ignored Field"
         }
     }
 }`

--- a/internal/converter/testdata/option_ignored_message.go
+++ b/internal/converter/testdata/option_ignored_message.go
@@ -23,7 +23,8 @@ const UnignoredMessage = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Unignored Message"
         }
     }
 }`

--- a/internal/converter/testdata/option_required_field.go
+++ b/internal/converter/testdata/option_required_field.go
@@ -21,7 +21,8 @@ const OptionRequiredField = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Option Required Field"
         }
     }
 }`

--- a/internal/converter/testdata/option_required_message.go
+++ b/internal/converter/testdata/option_required_message.go
@@ -30,7 +30,8 @@ const OptionRequiredMessage = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Option Required Message"
         }
     }
 }`

--- a/internal/converter/testdata/payload_message.go
+++ b/internal/converter/testdata/payload_message.go
@@ -43,11 +43,13 @@ const PayloadMessage = `{
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Payload Message"
         }
     }
 }`

--- a/internal/converter/testdata/payload_message_2.go
+++ b/internal/converter/testdata/payload_message_2.go
@@ -55,7 +55,8 @@ const PayloadMessage2 = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "description": "PayloadMessage2 contains some common types\n \n PayloadMessage2 is used throughout the test suite"
         }
     }
 }`

--- a/internal/converter/testdata/payload_message_2.go
+++ b/internal/converter/testdata/payload_message_2.go
@@ -51,12 +51,14 @@ const PayloadMessage2 = `{
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
             "type": "object",
-            "description": "PayloadMessage2 contains some common types\n \n PayloadMessage2 is used throughout the test suite"
+            "title": "Payload Message 2",
+            "description": "PayloadMessage2 contains some common types\n \n PayloadMessage2 is used throughout the test suite\n and can have multi-line comments"
         }
     }
 }`

--- a/internal/converter/testdata/proto/MessageWithComments.proto
+++ b/internal/converter/testdata/proto/MessageWithComments.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package samples;
 
-// This is a detached leading comment (which becomes the title)
+// This is a leading detached comment (which becomes the title)
 
 // This is a message level comment and talks about what this message is and why you should care about it!
 message MessageWithComments {

--- a/internal/converter/testdata/proto/MessageWithComments.proto
+++ b/internal/converter/testdata/proto/MessageWithComments.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package samples;
 
+// This is a detached leading comment (which becomes the title)
+
 // This is a message level comment and talks about what this message is and why you should care about it!
 message MessageWithComments {
 

--- a/internal/converter/testdata/proto/PayloadMessage2.proto
+++ b/internal/converter/testdata/proto/PayloadMessage2.proto
@@ -4,6 +4,7 @@ package samples;
 // PayloadMessage2 contains some common types
 // 
 // PayloadMessage2 is used throughout the test suite
+// and can have multi-line comments
 message PayloadMessage2 {
     enum Topology {
         FLAT             = 0;

--- a/internal/converter/testdata/proto/PayloadMessage2.proto
+++ b/internal/converter/testdata/proto/PayloadMessage2.proto
@@ -1,6 +1,9 @@
 syntax = "proto3";
 package samples;
 
+// PayloadMessage2 contains some common types
+// 
+// PayloadMessage2 is used throughout the test suite
 message PayloadMessage2 {
     enum Topology {
         FLAT             = 0;

--- a/internal/converter/testdata/proto2_nested_message.go
+++ b/internal/converter/testdata/proto2_nested_message.go
@@ -18,7 +18,8 @@ const Proto2NestedMessage = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Proto 2 Nested Message"
         },
         "samples.Proto2PayloadMessage": {
             "required": [
@@ -63,11 +64,13 @@ const Proto2NestedMessage = `{
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Proto 2 Payload Message"
         }
     }
 }`

--- a/internal/converter/testdata/proto2_nested_object.go
+++ b/internal/converter/testdata/proto2_nested_object.go
@@ -19,7 +19,8 @@ const Proto2NestedObject = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Proto 2 Nested Object"
         },
         "samples.Proto2NestedObject.NestedPayload": {
             "required": [
@@ -68,11 +69,13 @@ const Proto2NestedObject = `{
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Nested Payload"
         }
     }
 }`

--- a/internal/converter/testdata/proto2_payload_message.go
+++ b/internal/converter/testdata/proto2_payload_message.go
@@ -47,11 +47,13 @@ const Proto2PayloadMessage = `{
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Proto 2 Payload Message"
         }
     }
 }`

--- a/internal/converter/testdata/proto2_required.go
+++ b/internal/converter/testdata/proto2_required.go
@@ -20,7 +20,8 @@ const Proto2Required = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Proto 2 Required"
         }
     }
 }`

--- a/internal/converter/testdata/second_enum.go
+++ b/internal/converter/testdata/second_enum.go
@@ -19,7 +19,8 @@ const SecondEnum = `{
         {
             "type": "integer"
         }
-    ]
+    ],
+    "title": "Second Enum"
 }`
 
 const SecondEnumFail = `"VALUE_3"`

--- a/internal/converter/testdata/second_message.go
+++ b/internal/converter/testdata/second_message.go
@@ -23,7 +23,8 @@ const SecondMessage = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Second Message"
         }
     }
 }`

--- a/internal/converter/testdata/self_reference.go
+++ b/internal/converter/testdata/self_reference.go
@@ -17,7 +17,8 @@ const SelfReference = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Foo"
         }
     }
 }`

--- a/internal/converter/testdata/timestamp.go
+++ b/internal/converter/testdata/timestamp.go
@@ -12,7 +12,8 @@ const Timestamp = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Timestamp"
         }
     }
 }`

--- a/internal/converter/testdata/wellknown.go
+++ b/internal/converter/testdata/wellknown.go
@@ -26,6 +26,7 @@ const WellKnown = `{
                 "list_of_integers": {
                     "items": {
                         "type": "integer",
+                        "title": "Int 32 Value",
                         "description": "Wrapper message for ` + "`int32`" + `.\n\n The JSON representation for ` + "`Int32Value`" + ` is JSON number."
                     },
                     "type": "array"
@@ -42,7 +43,8 @@ const WellKnown = `{
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Well Known"
         }
     }
 }`

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -78,7 +78,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 
 	// Generate a description from src comments (if available)
 	if src := c.sourceInfo.GetField(desc); src != nil {
-		jsonSchemaType.Title, jsonSchemaType.Description = c.formatTitleAndDescription(src)
+		jsonSchemaType.Title, jsonSchemaType.Description = c.formatTitleAndDescription(nil, src)
 	}
 
 	// Switch the types, and pick a JSONSchema equivalent:
@@ -442,7 +442,7 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msgDesc *d
 
 	// Generate a description from src comments (if available)
 	if src := c.sourceInfo.GetMessage(msgDesc); src != nil {
-		jsonSchemaType.Title, jsonSchemaType.Description = c.formatTitleAndDescription(src)
+		jsonSchemaType.Title, jsonSchemaType.Description = c.formatTitleAndDescription(strPtr(msgDesc.GetName()), src)
 	}
 
 	// Handle google's well-known types:

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -78,7 +78,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 
 	// Generate a description from src comments (if available)
 	if src := c.sourceInfo.GetField(desc); src != nil {
-		_, jsonSchemaType.Description = formatTitleAndDescription(src)
+		jsonSchemaType.Title, jsonSchemaType.Description = formatTitleAndDescription(src)
 	}
 
 	// Switch the types, and pick a JSONSchema equivalent:
@@ -585,31 +585,6 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msgDesc *d
 	jsonSchemaType.Required = dedupe(jsonSchemaType.Required)
 
 	return jsonSchemaType, nil
-}
-
-func formatTitleAndDescription(sl *descriptor.SourceCodeInfo_Location) (title, description string) {
-	var comments []string
-	for _, str := range sl.GetLeadingDetachedComments() {
-		if s := strings.TrimSpace(str); s != "" {
-			comments = append(comments, s)
-		}
-	}
-	if s := strings.TrimSpace(sl.GetLeadingComments()); s != "" {
-		comments = append(comments, s)
-	}
-	if s := strings.TrimSpace(sl.GetTrailingComments()); s != "" {
-		comments = append(comments, s)
-	}
-
-	// The title becomes the first comment (if one exists):
-	if len(comments) > 1 {
-		title = comments[0]
-	}
-
-	// The description is all the comments joined together:
-	description = strings.Join(comments, "\n\n")
-
-	return
 }
 
 func dedupe(inputStrings []string) []string {

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -78,7 +78,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 
 	// Generate a description from src comments (if available)
 	if src := c.sourceInfo.GetField(desc); src != nil {
-		jsonSchemaType.Title, jsonSchemaType.Description = formatTitleAndDescription(src)
+		jsonSchemaType.Title, jsonSchemaType.Description = c.formatTitleAndDescription(src)
 	}
 
 	// Switch the types, and pick a JSONSchema equivalent:
@@ -442,7 +442,7 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msgDesc *d
 
 	// Generate a description from src comments (if available)
 	if src := c.sourceInfo.GetMessage(msgDesc); src != nil {
-		jsonSchemaType.Title, jsonSchemaType.Description = formatTitleAndDescription(src)
+		jsonSchemaType.Title, jsonSchemaType.Description = c.formatTitleAndDescription(src)
 	}
 
 	// Handle google's well-known types:

--- a/jsonschemas/ArrayOfEnums.json
+++ b/jsonschemas/ArrayOfEnums.json
@@ -20,11 +20,13 @@
                             3
                         ]
                     },
-                    "type": "array"
+                    "type": "array",
+                    "title": "Inline"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Array Of Enums"
         }
     }
 }

--- a/jsonschemas/ArrayOfMessages.json
+++ b/jsonschemas/ArrayOfMessages.json
@@ -36,7 +36,8 @@
                 {
                     "type": "object"
                 }
-            ]
+            ],
+            "title": "Array Of Messages"
         },
         "samples.PayloadMessage": {
             "properties": {
@@ -115,7 +116,8 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
@@ -126,7 +128,8 @@
                 {
                     "type": "object"
                 }
-            ]
+            ],
+            "title": "Payload Message"
         }
     }
 }

--- a/jsonschemas/ArrayOfObjects.json
+++ b/jsonschemas/ArrayOfObjects.json
@@ -36,7 +36,8 @@
                 {
                     "type": "object"
                 }
-            ]
+            ],
+            "title": "Array Of Objects"
         },
         "samples.ArrayOfObjects.RepeatedPayload": {
             "properties": {
@@ -115,7 +116,8 @@
                         {
                             "type": "null"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
@@ -126,7 +128,8 @@
                 {
                     "type": "object"
                 }
-            ]
+            ],
+            "title": "Repeated Payload"
         }
     }
 }

--- a/jsonschemas/ArrayOfPrimitives.json
+++ b/jsonschemas/ArrayOfPrimitives.json
@@ -93,7 +93,8 @@
                 {
                     "type": "object"
                 }
-            ]
+            ],
+            "title": "Array Of Primitives"
         }
     }
 }

--- a/jsonschemas/EnumOptions.json
+++ b/jsonschemas/EnumOptions.json
@@ -15,6 +15,7 @@
             },
             "additionalProperties": true,
             "type": "object",
+            "title": "Enum Options",
             "description": "Custom EnumOptions"
         }
     }

--- a/jsonschemas/Enumception.json
+++ b/jsonschemas/Enumception.json
@@ -34,6 +34,7 @@
                             "type": "integer"
                         }
                     ],
+                    "title": "Failure Modes",
                     "description": "FailureModes enum"
                 },
                 "payload": {
@@ -91,11 +92,13 @@
                             "const": 3
                         }
                     ],
+                    "title": "Imported Enum",
                     "description": "This is an enum"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Enumception"
         },
         "samples.PayloadMessage": {
             "properties": {
@@ -136,11 +139,13 @@
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Payload Message"
         }
     }
 }

--- a/jsonschemas/FieldOptions.json
+++ b/jsonschemas/FieldOptions.json
@@ -15,6 +15,7 @@
             },
             "additionalProperties": true,
             "type": "object",
+            "title": "Field Options",
             "description": "Custom FieldOptions"
         }
     }

--- a/jsonschemas/FileOptions.json
+++ b/jsonschemas/FileOptions.json
@@ -15,6 +15,7 @@
             },
             "additionalProperties": true,
             "type": "object",
+            "title": "File Options",
             "description": "Custom FileOptions"
         }
     }

--- a/jsonschemas/FirstEnum.json
+++ b/jsonschemas/FirstEnum.json
@@ -17,5 +17,6 @@
         {
             "type": "integer"
         }
-    ]
+    ],
+    "title": "First Enum"
 }

--- a/jsonschemas/FirstMessage.json
+++ b/jsonschemas/FirstMessage.json
@@ -21,7 +21,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "First Message"
         }
     }
 }

--- a/jsonschemas/GoogleValue.json
+++ b/jsonschemas/GoogleValue.json
@@ -22,11 +22,13 @@
                             "type": "string"
                         }
                     ],
-                    "description": "`Value` represents a dynamically typed value which can be either\n null, a number, a string, a boolean, a recursive struct value, or a\n list of values. A producer of value is expected to set one of that\n variants, absence of any variant indicates an error.\n\n The JSON representation for `Value` is JSON value."
+                    "title": "Value",
+                    "description": "`Value` represents a dynamically typed value which can be either\n null, a number, a string, a boolean, a recursive struct value, or a\n list of values. A producer of value is expected to set one of these\n variants. Absence of any variant indicates an error.\n\n The JSON representation for `Value` is JSON value."
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Google Value"
         }
     }
 }

--- a/jsonschemas/ImportedEnum.json
+++ b/jsonschemas/ImportedEnum.json
@@ -44,5 +44,6 @@
             "const": 3
         }
     ],
+    "title": "Imported Enum",
     "description": "This is an enum"
 }

--- a/jsonschemas/Maps.json
+++ b/jsonschemas/Maps.json
@@ -25,7 +25,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Maps"
         },
         "samples.PayloadMessage": {
             "properties": {
@@ -66,11 +67,13 @@
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Payload Message"
         }
     }
 }

--- a/jsonschemas/MessageKind10.json
+++ b/jsonschemas/MessageKind10.json
@@ -21,7 +21,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 10"
         }
     }
 }

--- a/jsonschemas/MessageKind11.json
+++ b/jsonschemas/MessageKind11.json
@@ -27,7 +27,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 11"
         },
         "samples.MessageKind1": {
             "properties": {
@@ -48,7 +49,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 1"
         },
         "samples.MessageKind2": {
             "properties": {
@@ -75,7 +77,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 2"
         },
         "samples.MessageKind3": {
             "properties": {
@@ -99,7 +102,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 3"
         },
         "samples.MessageKind4": {
             "properties": {
@@ -123,7 +127,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 4"
         }
     }
 }

--- a/jsonschemas/MessageKind12.json
+++ b/jsonschemas/MessageKind12.json
@@ -25,7 +25,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 12"
         },
         "samples.MessageKind1": {
             "properties": {
@@ -46,7 +47,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 1"
         },
         "samples.MessageKind11": {
             "properties": {
@@ -73,7 +75,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 11"
         },
         "samples.MessageKind2": {
             "properties": {
@@ -100,7 +103,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 2"
         },
         "samples.MessageKind3": {
             "properties": {
@@ -124,7 +128,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 3"
         },
         "samples.MessageKind4": {
             "properties": {
@@ -148,7 +153,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 4"
         },
         "samples.MessageKind5": {
             "properties": {
@@ -172,7 +178,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 5"
         },
         "samples.MessageKind6": {
             "properties": {
@@ -196,7 +203,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 6"
         },
         "samples.MessageKind7": {
             "properties": {
@@ -220,7 +228,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Message Kind 7"
         }
     }
 }

--- a/jsonschemas/MessageOptions.json
+++ b/jsonschemas/MessageOptions.json
@@ -27,6 +27,7 @@
             },
             "additionalProperties": true,
             "type": "object",
+            "title": "Message Options",
             "description": "Custom MessageOptions"
         }
     }

--- a/jsonschemas/MessageWithComments.json
+++ b/jsonschemas/MessageWithComments.json
@@ -11,7 +11,8 @@
             },
             "additionalProperties": true,
             "type": "object",
-            "description": "This is a message level comment and talks about what this message is and why you should care about it!"
+            "title": "This is a leading detached comment (which becomes the title)",
+            "description": "This is a leading detached comment (which becomes the title)  This is a message level comment and talks about what this message is and why you should care about it!"
         }
     }
 }

--- a/jsonschemas/NestedMessage.json
+++ b/jsonschemas/NestedMessage.json
@@ -13,7 +13,8 @@
                 }
             },
             "additionalProperties": false,
-            "type": "object"
+            "type": "object",
+            "title": "Nested Message"
         },
         "samples.PayloadMessage": {
             "properties": {
@@ -54,11 +55,13 @@
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": false,
-            "type": "object"
+            "type": "object",
+            "title": "Payload Message"
         }
     }
 }

--- a/jsonschemas/NestedObject.json
+++ b/jsonschemas/NestedObject.json
@@ -13,7 +13,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Nested Object"
         },
         "samples.NestedObject.NestedPayload": {
             "properties": {
@@ -54,11 +55,13 @@
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Nested Payload"
         }
     }
 }

--- a/jsonschemas/OneOf.json
+++ b/jsonschemas/OneOf.json
@@ -29,7 +29,8 @@
                         "baz"
                     ]
                 }
-            ]
+            ],
+            "title": "One Of"
         },
         "samples.OneOf.Bar": {
             "properties": {
@@ -38,7 +39,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Bar"
         },
         "samples.OneOf.Baz": {
             "properties": {
@@ -47,7 +49,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Baz"
         }
     }
 }

--- a/jsonschemas/OptionAllowNullValues.json
+++ b/jsonschemas/OptionAllowNullValues.json
@@ -43,7 +43,8 @@
                 {
                     "type": "object"
                 }
-            ]
+            ],
+            "title": "Option Allow Null Values"
         }
     }
 }

--- a/jsonschemas/OptionDisallowAdditionalProperties.json
+++ b/jsonschemas/OptionDisallowAdditionalProperties.json
@@ -21,7 +21,8 @@
                 }
             },
             "additionalProperties": false,
-            "type": "object"
+            "type": "object",
+            "title": "Option Disallow Additional Properties"
         }
     }
 }

--- a/jsonschemas/OptionEnumsAsConstants.json
+++ b/jsonschemas/OptionEnumsAsConstants.json
@@ -49,11 +49,13 @@
                             "const": 3
                         }
                     ],
+                    "title": "Imported Enum",
                     "description": "This is an enum"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Option Enums As Constants"
         }
     }
 }

--- a/jsonschemas/OptionFileExtension.jsonschema
+++ b/jsonschemas/OptionFileExtension.jsonschema
@@ -21,7 +21,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Option File Extension"
         }
     }
 }

--- a/jsonschemas/OptionIgnoredField.json
+++ b/jsonschemas/OptionIgnoredField.json
@@ -12,7 +12,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Option Ignored Field"
         }
     }
 }

--- a/jsonschemas/OptionRequiredMessage.json
+++ b/jsonschemas/OptionRequiredMessage.json
@@ -28,7 +28,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Option Required Message"
         }
     }
 }

--- a/jsonschemas/PayloadMessage.json
+++ b/jsonschemas/PayloadMessage.json
@@ -41,11 +41,13 @@
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Payload Message"
         }
     }
 }

--- a/jsonschemas/PayloadMessage2.json
+++ b/jsonschemas/PayloadMessage2.json
@@ -49,11 +49,14 @@
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Payload Message 2",
+            "description": "PayloadMessage2 contains some common types\n \n PayloadMessage2 is used throughout the test suite\n and can have multi-line comments"
         }
     }
 }

--- a/jsonschemas/Proto2NestedMessage.json
+++ b/jsonschemas/Proto2NestedMessage.json
@@ -16,7 +16,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Proto 2 Nested Message"
         },
         "samples.Proto2PayloadMessage": {
             "required": [
@@ -61,11 +62,13 @@
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Proto 2 Payload Message"
         }
     }
 }

--- a/jsonschemas/Proto2NestedObject.json
+++ b/jsonschemas/Proto2NestedObject.json
@@ -17,7 +17,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Proto 2 Nested Object"
         },
         "samples.Proto2NestedObject.NestedPayload": {
             "required": [
@@ -66,11 +67,13 @@
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Nested Payload"
         }
     }
 }

--- a/jsonschemas/Proto2PayloadMessage.json
+++ b/jsonschemas/Proto2PayloadMessage.json
@@ -45,11 +45,13 @@
                         {
                             "type": "integer"
                         }
-                    ]
+                    ],
+                    "title": "Topology"
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Proto 2 Payload Message"
         }
     }
 }

--- a/jsonschemas/Proto2Required.json
+++ b/jsonschemas/Proto2Required.json
@@ -18,7 +18,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Proto 2 Required"
         }
     }
 }

--- a/jsonschemas/SecondEnum.json
+++ b/jsonschemas/SecondEnum.json
@@ -17,5 +17,6 @@
         {
             "type": "integer"
         }
-    ]
+    ],
+    "title": "Second Enum"
 }

--- a/jsonschemas/SecondMessage.json
+++ b/jsonschemas/SecondMessage.json
@@ -21,7 +21,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Second Message"
         }
     }
 }

--- a/jsonschemas/Timestamp.json
+++ b/jsonschemas/Timestamp.json
@@ -10,7 +10,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Timestamp"
         }
     }
 }

--- a/jsonschemas/UnignoredMessage.json
+++ b/jsonschemas/UnignoredMessage.json
@@ -21,7 +21,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Unignored Message"
         }
     }
 }

--- a/jsonschemas/WellKnown.json
+++ b/jsonschemas/WellKnown.json
@@ -24,6 +24,7 @@
                 "list_of_integers": {
                     "items": {
                         "type": "integer",
+                        "title": "Int 32 Value",
                         "description": "Wrapper message for `int32`.\n\n The JSON representation for `Int32Value` is JSON number."
                     },
                     "type": "array"
@@ -40,7 +41,8 @@
                 }
             },
             "additionalProperties": true,
-            "type": "object"
+            "type": "object",
+            "title": "Well Known"
         }
     }
 }


### PR DESCRIPTION
In response to an issue raised by @mrozycki-tink, this PR introduces new behaviour which uses the first line of [protobuf comments](https://github.com/protocolbuffers/protobuf-go/blob/master/types/descriptorpb/descriptor.pb.go#L2859) to populate the JSONSchema `title` field (but only if there are more than one comments).

In this example the title would be "Thing":
```proto
// Thing

// This is a thing.
message Thing {
  ...
}
```

The protobuf library describes this as being a "detached" comment, which to me seems like a good way to pick a title.