### PR TITLE
Fixes `enums_as_strings_only` config to match documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The following configuration parameters are supported. They should be added to th
 |`disallow_additional_properties`| Disallow additional properties in schema |
 |`disallow_bigints_as_strings`| Disallow big integers as strings |
 |`enforce_oneof`| Interpret Proto "oneOf" clauses |
-|`enum_as_strings_only`| Only include strings in the allowed values for enums |
+|`enums_as_strings_only`| Only include strings in the allowed values for enums |
 |`file_extension`| Specify a custom file extension for generated schemas |
 |`json_fieldnames`| Use JSON field names only |
 |`prefix_schema_files_with_package`| Prefix the output filename with package |

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -104,7 +104,7 @@ func (c *Converter) parseGeneratorParameters(parameters string) {
 			c.Flags.DisallowBigIntsAsStrings = true
 		case "enforce_oneof":
 			c.Flags.EnforceOneOf = true
-		case "enum_as_strings_only":
+		case "enums_as_strings_only":
 			c.Flags.EnumsAsStringsOnly = true
 		case "json_fieldnames":
 			c.Flags.UseJSONFieldnamesOnly = true


### PR DESCRIPTION
The documentation makes reference to `enums_as_strings_only` and `enums_as_constants` (although there doesn't actually look to be a converter flag for that one) here: https://github.com/chrusty/protoc-gen-jsonschema/blame/master/README.md#L97. This PR fixes the converter value for this flag and also updates the other reference to it in the README so all should now be consistent.

Alternatively, we could fix both references in the docs, but then we would probably want to update all the `ConverterFlags` to be consistent.