### PR TITLE
119 bug when disallowing bigints and allowing null values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.14
 
 require (
 	github.com/alecthomas/jsonschema v0.0.0-20210918223802-a1d3f4b43d7b
-	github.com/fatih/camelcase v1.0.0 // indirect
+	github.com/fatih/camelcase v1.0.0
 	github.com/iancoleman/orderedmap v0.2.0
-	github.com/iancoleman/strcase v0.2.0 // indirect
+	github.com/iancoleman/strcase v0.2.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/sirupsen/logrus v1.4.2
@@ -16,4 +16,5 @@ require (
 	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 h1:ng0gs1AKnRRuEMZoTLLlbOd+C17zUDepwGQBb/n+JVg=
-golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 h1:OH54vjqzRWmbJ62fjuhxy7AxFFgoHN0/DPc/UrL8cAs=
 golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
@@ -52,5 +50,6 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -172,6 +172,10 @@ func configureSampleProtos() map[string]sampleProto {
 			ObjectsToValidatePass: []string{testdata.ArrayOfPrimitivesDoublePass},
 		},
 		"BigIntAsString": {
+			Flags: ConverterFlags{
+				AllowNullValues:          true,
+				DisallowBigIntsAsStrings: true,
+			},
 			ExpectedJSONSchema:    []string{testdata.BigIntAsString},
 			FilesToGenerate:       []string{"BigIntAsString.proto"},
 			ProtoFileName:         "BigIntAsString.proto",

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -171,6 +171,13 @@ func configureSampleProtos() map[string]sampleProto {
 			ObjectsToValidateFail: []string{testdata.ArrayOfPrimitivesDoubleFail},
 			ObjectsToValidatePass: []string{testdata.ArrayOfPrimitivesDoublePass},
 		},
+		"BigIntAsString": {
+			ExpectedJSONSchema:    []string{testdata.BigIntAsString},
+			FilesToGenerate:       []string{"BigIntAsString.proto"},
+			ProtoFileName:         "BigIntAsString.proto",
+			ObjectsToValidateFail: []string{testdata.BigIntAsStringFail},
+			ObjectsToValidatePass: []string{testdata.BigIntAsStringPass},
+		},
 		"BytesPayload": {
 			ExpectedJSONSchema:    []string{testdata.BytesPayload},
 			FilesToGenerate:       []string{"BytesPayload.proto"},

--- a/internal/converter/testdata/bigint_as_string.go
+++ b/internal/converter/testdata/bigint_as_string.go
@@ -9,7 +9,7 @@ const BigIntAsString = `{
                 "big_number": {
                     "oneOf": [
                         {
-                            "type": "number"
+                            "type": "integer"
                         },
                         {
                             "type": "null"

--- a/internal/converter/testdata/bigint_as_string.go
+++ b/internal/converter/testdata/bigint_as_string.go
@@ -1,0 +1,36 @@
+package testdata
+
+const BigIntAsString = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/BigIntAsString",
+    "definitions": {
+        "BigIntAsString": {
+            "properties": {
+                "big_number": {
+                    "oneOf": [
+                        {
+                            "type": "number"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": true,
+            "oneOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "object"
+                }
+            ],
+            "title": "Big Int As String"
+        }
+    }
+}`
+
+const BigIntAsStringFail = `{"big_number": "1827634182736443333"}`
+
+const BigIntAsStringPass = `{"big_number": 1827634182736443333}`

--- a/internal/converter/testdata/proto/BigIntAsString.proto
+++ b/internal/converter/testdata/proto/BigIntAsString.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package samples;
+import "options.proto";
+
+message BigIntAsString {
+    option (protoc.gen.jsonschema.message_options).allow_null_values = true;
+    int64 big_number = 1;
+}


### PR DESCRIPTION
Fixing a bug where bigint schemas rendered as "string" values, even when the disallow-bigint-as-strings option was used. This only happened in conjunction with the allow-nulls option.

This PR introduces a fix for the above scenario.