### PR TITLE
Treating google.protobuf.ListValue as an array

### DIFF
--- a/internal/converter/testdata/google_value.go
+++ b/internal/converter/testdata/google_value.go
@@ -26,6 +26,37 @@ const GoogleValue = `{
                     ],
                     "title": "Value",
                     "description": "` + "`Value`" + ` represents a dynamically typed value which can be either null, a number, a string, a boolean, a recursive struct value, or a list of values. A producer of value is expected to set one of these variants. Absence of any variant indicates an error. The JSON representation for ` + "`Value`" + ` is JSON value."
+                },
+                "some_list": {
+                    "properties": {
+                        "values": {
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "type": "number"
+                                    },
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "title": "Value",
+                                "description": "` + "`Value`" + ` represents a dynamically typed value which can be either null, a number, a string, a boolean, a recursive struct value, or a list of values. A producer of value is expected to set one of these variants. Absence of any variant indicates an error. The JSON representation for ` + "`Value`" + ` is JSON value."
+                            },
+                            "type": "array",
+                            "description": "Repeated field of dynamically typed values."
+                        }
+                    },
+                    "additionalProperties": true,
+                    "type": "object"
                 }
             },
             "additionalProperties": true,
@@ -33,7 +64,8 @@ const GoogleValue = `{
             "title": "Google Value"
         }
     }
-}`
+}
+`
 
 const GoogleValueFail = `{"arg": null}`
 

--- a/internal/converter/testdata/google_value.go
+++ b/internal/converter/testdata/google_value.go
@@ -28,35 +28,8 @@ const GoogleValue = `{
                     "description": "` + "`Value`" + ` represents a dynamically typed value which can be either null, a number, a string, a boolean, a recursive struct value, or a list of values. A producer of value is expected to set one of these variants. Absence of any variant indicates an error. The JSON representation for ` + "`Value`" + ` is JSON value."
                 },
                 "some_list": {
-                    "properties": {
-                        "values": {
-                            "items": {
-                                "oneOf": [
-                                    {
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "boolean"
-                                    },
-                                    {
-                                        "type": "number"
-                                    },
-                                    {
-                                        "type": "object"
-                                    },
-                                    {
-                                        "type": "string"
-                                    }
-                                ],
-                                "title": "Value",
-                                "description": "` + "`Value`" + ` represents a dynamically typed value which can be either null, a number, a string, a boolean, a recursive struct value, or a list of values. A producer of value is expected to set one of these variants. Absence of any variant indicates an error. The JSON representation for ` + "`Value`" + ` is JSON value."
-                            },
-                            "type": "array",
-                            "description": "Repeated field of dynamically typed values."
-                        }
-                    },
                     "additionalProperties": true,
-                    "type": "object"
+                    "type": "array"
                 }
             },
             "additionalProperties": true,
@@ -67,6 +40,6 @@ const GoogleValue = `{
 }
 `
 
-const GoogleValueFail = `{"arg": null}`
+const GoogleValueFail = `{"arg": null, "some_list": 4}`
 
-const GoogleValuePass = `{"arg": 12345}`
+const GoogleValuePass = `{"arg": 12345, "some_list": [1,2,3,4]}`

--- a/internal/converter/testdata/proto/GoogleValue.proto
+++ b/internal/converter/testdata/proto/GoogleValue.proto
@@ -5,4 +5,5 @@ import "google/protobuf/struct.proto";
 
 message GoogleValue {
   google.protobuf.Value arg = 1;
+  google.protobuf.ListValue some_list = 2;
 }

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -18,18 +18,19 @@ var (
 	globalPkg = newProtoPackage(nil, "")
 
 	wellKnownTypes = map[string]bool{
-		"DoubleValue": true,
-		"FloatValue":  true,
-		"Int64Value":  true,
-		"UInt64Value": true,
-		"Int32Value":  true,
-		"UInt32Value": true,
 		"BoolValue":   true,
-		"StringValue": true,
 		"BytesValue":  true,
-		"Value":       true,
+		"DoubleValue": true,
 		"Duration":    true,
+		"FloatValue":  true,
+		"Int32Value":  true,
+		"Int64Value":  true,
+		"ListValue":   true,
+		"StringValue": true,
 		"Struct":      true,
+		"UInt32Value": true,
+		"UInt64Value": true,
+		"Value":       true,
 	}
 )
 

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -532,6 +532,8 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msgDesc *d
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
 		case "Struct":
 			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
+		case "ListValue":
+			jsonSchemaType.Type = gojsonschema.TYPE_ARRAY
 		}
 
 		// If we're allowing nulls then prepare a OneOf:


### PR DESCRIPTION
This relates to issue https://github.com/chrusty/protoc-gen-jsonschema/issues/143.

Added google.protobuf.ListValue as one of the specially handled Google types.