### PR TITLE
[Issue 141] Struct and value need additional properties

### DIFF
--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -221,6 +221,7 @@ func configureSampleProtos() map[string]sampleProto {
 			ObjectsToValidatePass: []string{testdata.PayloadMessagePass, testdata.ImportedEnumPass, testdata.EnumCeptionPass},
 		},
 		"GoogleValue": {
+			Flags:                 ConverterFlags{DisallowAdditionalProperties: true},
 			ExpectedJSONSchema:    []string{testdata.GoogleValue},
 			FilesToGenerate:       []string{"GoogleValue.proto"},
 			ProtoFileName:         "GoogleValue.proto",

--- a/internal/converter/testdata/google_value.go
+++ b/internal/converter/testdata/google_value.go
@@ -28,11 +28,15 @@ const GoogleValue = `{
                     "description": "` + "`Value`" + ` represents a dynamically typed value which can be either null, a number, a string, a boolean, a recursive struct value, or a list of values. A producer of value is expected to set one of these variants. Absence of any variant indicates an error. The JSON representation for ` + "`Value`" + ` is JSON value."
                 },
                 "some_list": {
-                    "additionalProperties": true,
+                    "additionalProperties": false,
                     "type": "array"
+                },
+                "some_struct": {
+                    "additionalProperties": true,
+                    "type": "object"
                 }
             },
-            "additionalProperties": true,
+            "additionalProperties": false,
             "type": "object",
             "title": "Google Value"
         }

--- a/internal/converter/testdata/proto/GoogleValue.proto
+++ b/internal/converter/testdata/proto/GoogleValue.proto
@@ -6,4 +6,5 @@ import "google/protobuf/struct.proto";
 message GoogleValue {
   google.protobuf.Value arg = 1;
   google.protobuf.ListValue some_list = 2;
+  google.protobuf.Struct some_struct = 3;
 }

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -245,7 +245,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			jsonSchemaType.Format = "date-time"
 		case ".google.protobuf.Value", ".google.protobuf.Struct":
 			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
-			// jsonSchemaType.AdditionalProperties = []byte("true")
+			jsonSchemaType.AdditionalProperties = []byte("true")
 		default:
 			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
 			if desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_OPTIONAL {

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -243,6 +243,9 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		case ".google.protobuf.Timestamp":
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
 			jsonSchemaType.Format = "date-time"
+		case ".google.protobuf.Value", ".google.protobuf.Struct":
+			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
+			// jsonSchemaType.AdditionalProperties = []byte("true")
 		default:
 			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
 			if desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_OPTIONAL {
@@ -538,10 +541,12 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msgDesc *d
 				{Type: gojsonschema.TYPE_OBJECT},
 				{Type: gojsonschema.TYPE_STRING},
 			}
+			// jsonSchemaType.AdditionalProperties = []byte("true")
 		case "Duration":
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
 		case "Struct":
 			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
+			// jsonSchemaType.AdditionalProperties = []byte("true")
 		case "ListValue":
 			jsonSchemaType.Type = gojsonschema.TYPE_ARRAY
 		}


### PR DESCRIPTION
This PR addresses [an issue](https://github.com/chrusty/protoc-gen-jsonschema/issues/141) raised which involved `google.protobuf.Value` and `google.protobuf.Struct` not behaving properly when the `DisallowAdditionalProperties` option was used.

By their very nature these types have unknowable properties, so they need to be allowed in every case.