### PR TITLE
Fix array syntax in oneOf to include items

### DIFF
--- a/internal/converter/testdata/array_of_objects.go
+++ b/internal/converter/testdata/array_of_objects.go
@@ -17,14 +17,14 @@ const ArrayOfObjects = `{
                     ]
                 },
                 "payload": {
-                    "items": {
-                        "$ref": "#/definitions/samples.ArrayOfObjects.RepeatedPayload"
-                    },
                     "oneOf": [
                         {
                             "type": "null"
                         },
                         {
+                            "items": {
+                                "$ref": "#/definitions/samples.ArrayOfObjects.RepeatedPayload"
+                            },
                             "type": "array"
                         }
                     ]

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -382,9 +382,10 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		if messageFlags.AllowNullValues {
 			jsonSchemaType.OneOf = []*jsonschema.Type{
 				{Type: gojsonschema.TYPE_NULL},
-				{Type: jsonSchemaType.Type},
+				{Type: jsonSchemaType.Type, Items: jsonSchemaType.Items},
 			}
 			jsonSchemaType.Type = ""
+			jsonSchemaType.Items = nil
 		}
 	}
 

--- a/jsonschemas/ArrayOfMessages.json
+++ b/jsonschemas/ArrayOfMessages.json
@@ -15,14 +15,14 @@
                     ]
                 },
                 "payload": {
-                    "items": {
-                        "$ref": "#/definitions/samples.PayloadMessage"
-                    },
                     "oneOf": [
                         {
                             "type": "null"
                         },
                         {
+                            "items": {
+                                "$ref": "#/definitions/samples.PayloadMessage"
+                            },
                             "type": "array"
                         }
                     ]

--- a/jsonschemas/ArrayOfObjects.json
+++ b/jsonschemas/ArrayOfObjects.json
@@ -15,14 +15,14 @@
                     ]
                 },
                 "payload": {
-                    "items": {
-                        "$ref": "#/definitions/samples.ArrayOfObjects.RepeatedPayload"
-                    },
                     "oneOf": [
                         {
                             "type": "null"
                         },
                         {
+                            "items": {
+                                "$ref": "#/definitions/samples.ArrayOfObjects.RepeatedPayload"
+                            },
                             "type": "array"
                         }
                     ]

--- a/jsonschemas/GoogleValue.json
+++ b/jsonschemas/GoogleValue.json
@@ -28,6 +28,10 @@
                 "some_list": {
                     "additionalProperties": true,
                     "type": "array"
+                },
+                "some_struct": {
+                    "additionalProperties": true,
+                    "type": "object"
                 }
             },
             "additionalProperties": true,


### PR DESCRIPTION
This is the fix for this issue: https://github.com/chrusty/protoc-gen-jsonschema/issues/154

`"items"` should be at the same level as the `"type":"array"` in the `oneOf` field when using option `allow_null_values`. 