### PR TITLE
Add `type_names_with_no_package` option to generate schemas without fully qualified package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ protoc \
 |`json_fieldnames`| Use JSON field names only |
 |`prefix_schema_files_with_package`| Prefix the output filename with package |
 |`proto_and_json_fieldnames`| Use proto and JSON field names |
+|`type_names_with_no_package`| When generating type names and refs, do not include the full package in the type name |
 
 
 Custom Proto Options
@@ -239,6 +240,16 @@ protoc \
 --proto_path=internal/converter/testdata/proto internal/converter/testdata/proto/ArrayOfPrimitives.proto
 ```
 
+### Generate type names without fully qualified package
+
+By default, referenced type names will be generated using the fully qualified package and type name. e.g `packageName.TypeName`.
+Setting this option will generate type names and their references only as `TypeName`
+
+```sh
+protoc \
+--jsonschema_out=type_names_with_no_package:. \
+--proto_path=internal/converter/testdata/proto internal/converter/testdata/proto/ArrayOfPrimitives.proto
+```
 
 Sample protos (for testing)
 ---------------------------

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -59,6 +59,7 @@ type ConverterFlags struct {
 	PrefixSchemaFilesWithPackage bool
 	UseJSONFieldnamesOnly        bool
 	UseProtoAndJSONFieldNames    bool
+	TypeNamesWithNoPackage       bool
 }
 
 // New returns a configured *Converter (defaulting to draft-04 version):
@@ -118,6 +119,8 @@ func (c *Converter) parseGeneratorParameters(parameters string) {
 			c.Flags.PrefixSchemaFilesWithPackage = true
 		case "proto_and_json_fieldnames":
 			c.Flags.UseProtoAndJSONFieldNames = true
+		case "type_names_with_no_package":
+			c.Flags.TypeNamesWithNoPackage = true
 		}
 
 		// look for specific message targets

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -144,6 +144,14 @@ func configureSampleProtos() map[string]sampleProto {
 			ObjectsToValidateFail: []string{testdata.PayloadMessageFail, testdata.ArrayOfMessagesFail},
 			ObjectsToValidatePass: []string{testdata.PayloadMessagePass, testdata.ArrayOfMessagesPass},
 		},
+		"TypeNamesWithNoPackage": {
+			Flags:                 ConverterFlags{TypeNamesWithNoPackage: true},
+			ExpectedJSONSchema:    []string{testdata.PayloadMessage, testdata.TypeNamesWithNoPackage},
+			FilesToGenerate:       []string{"ArrayOfMessages.proto", "PayloadMessage.proto"},
+			ProtoFileName:         "ArrayOfMessages.proto",
+			ObjectsToValidateFail: []string{testdata.PayloadMessageFail, testdata.TypeNamesWithNoPackageFail},
+			ObjectsToValidatePass: []string{testdata.PayloadMessagePass, testdata.TypeNamesWithNoPackagePass},
+		},
 		"ArrayOfObjects": {
 			Flags:                 ConverterFlags{AllowNullValues: true},
 			ExpectedJSONSchema:    []string{testdata.ArrayOfObjects},

--- a/internal/converter/testdata/type_names_with_no_package.go
+++ b/internal/converter/testdata/type_names_with_no_package.go
@@ -1,0 +1,85 @@
+package testdata
+
+const TypeNamesWithNoPackage = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/ArrayOfMessages",
+    "definitions": {
+        "ArrayOfMessages": {
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "payload": {
+                    "items": {
+                        "$ref": "#/definitions/PayloadMessage"
+                    },
+                    "type": "array"
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Array Of Messages"
+        },
+        "PayloadMessage": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "timestamp": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "rating": {
+                    "type": "number"
+                },
+                "complete": {
+                    "type": "boolean"
+                },
+                "topology": {
+                    "enum": [
+                        "FLAT",
+                        0,
+                        "NESTED_OBJECT",
+                        1,
+                        "NESTED_MESSAGE",
+                        2,
+                        "ARRAY_OF_TYPE",
+                        3,
+                        "ARRAY_OF_OBJECT",
+                        4,
+                        "ARRAY_OF_MESSAGE",
+                        5
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "title": "Topology"
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Payload Message"
+        }
+    }
+}`
+
+const TypeNamesWithNoPackageFail = `{
+    "description": "something",
+    "payload": [
+        {"topology": "cruft"}
+    ]
+}`
+
+const TypeNamesWithNoPackagePass = `{
+    "description": "something",
+    "payload": [
+        {"topology": "ARRAY_OF_MESSAGE"}
+    ]
+}`


### PR DESCRIPTION
Hi there!

tl;dr: This PR adds an option to disable fully qualified package type names, so they can be used for additional code generation.

More details:

I'm using this protobuf plugin to generate message schemas in both protobuf, as well as JSON compatible Java objects. My workflow is:

1. Define messages in protobuf format.
2. Use `protoc-gen-jsonschema` to generate a JSON Schema of objects.
3. Use [jsonschema2pojo](https://github.com/joelittlejohn/jsonschema2pojo) to convert the JSON schema into plain old java object code.

The problem:

jsonschema2pojo needs package unqualified type names to generate proper class names, otherwise type names such as `sample.MyMessage` will generate a Java class named `SampleMyMessage`, instead of just `MyMessage`. jsonschema2pojo also treats dots as ref fragment delimiters by default, which breaks compilation entirely.

I added a simple flag that allows the caller to specify whether we want to generate package qualified type names (and their references) or not.

Thanks for the great tool, let me know what you think!

Tests: Unit.